### PR TITLE
ci: update actions workflow to compile using swift 5.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
           echo "sha=$sha" >> $GITHUB_OUTPUT && cd ..
 
       - uses: actions/cache@v3
+        id: cache-swift-format
         with:
           path: ~/.build
           key: ${{ runner.os }}-swift-format-${{ steps.commit-sha.outputs.sha }}


### PR DESCRIPTION
FoundationNetworking (Apples SwiftNIO based networking module for Linux, without dependencies on the built-in proprietary macOS networking layer) only supports WebSockets starting with the Swift 5.8 toolchain.

Since those will be essential for both the IRC and the PubSub/EventSub implementations, this updates the Actions workflows to use both a Swift 5.8 snapshot for building & testing as well as the main development version of apple/swift-format which supports Swift 5.8