### PR TITLE
refactor: implement endpoint-specific custom response parsing

### DIFF
--- a/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+getAdSchedule.swift
+++ b/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+getAdSchedule.swift
@@ -11,9 +11,7 @@ where
       queryItems: { auth in
         [("broadcaster_id", auth.userID)]
       },
-      makeResponse: { response in
-        response.data
-      })
+      makeResponse: { $0.data })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+getAdSchedule.swift
+++ b/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+getAdSchedule.swift
@@ -1,10 +1,21 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<AdSchedule> {
-  public static func getAdSchedule(of channel: UserID) -> Self {
-    let queryItems = makeQueryItems(("broadcaster_id", channel))
-
-    return .init(method: "GET", path: "channels/ads", queryItems: queryItems)
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [AdSchedule], HelixResponseType == AdSchedule
+{
+  public static func getAdSchedule() -> Self {
+    return .init(
+      method: "GET", path: "channels/ads",
+      queryItems: { auth in
+        [
+          "broadcaster_id": auth.userID
+        ]
+      },
+      makeResponse: { response in
+        response.data
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+getAdSchedule.swift
+++ b/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+getAdSchedule.swift
@@ -9,9 +9,7 @@ where
     return .init(
       method: "GET", path: "channels/ads",
       queryItems: { auth in
-        [
-          "broadcaster_id": auth.userID
-        ]
+        [("broadcaster_id", auth.userID)]
       },
       makeResponse: { response in
         response.data

--- a/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+snoozeNextAd.swift
+++ b/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+snoozeNextAd.swift
@@ -9,7 +9,7 @@ where
     return .init(
       method: "POST", path: "channels/ads/schedule/snooze",
       queryItems: { auth in
-        ["broadcaster_id": auth.userID]
+        [("broadcaster_id", auth.userID)]
       },
       makeResponse: { result in
         guard let response = result.data.first else {

--- a/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+snoozeNextAd.swift
+++ b/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+snoozeNextAd.swift
@@ -1,11 +1,24 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<SnoozeResult> {
-  public static func snoozeNextAd(on channel: UserID) -> Self {
-    let queryItems = makeQueryItems(("broadcaster_id", channel))
-
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == SnoozeResult, HelixResponseType == SnoozeResult
+{
+  public static func snoozeNextAd() -> Self {
     return .init(
-      method: "POST", path: "channels/ads/schedule/snooze", queryItems: queryItems)
+      method: "POST", path: "channels/ads/schedule/snooze",
+      queryItems: { auth in
+        ["broadcaster_id": auth.userID]
+      },
+      makeResponse: { result in
+        guard let response = result.data.first else {
+          throw HelixError.noDataInResponse
+        }
+
+        return response
+      }
+    )
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+startCommercial.swift
+++ b/Sources/Twitch/Helix/Endpoints/Ads/HelixEndpoint+startCommercial.swift
@@ -1,10 +1,23 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Object<Commercial> {
-  public static func startCommercial(on channel: UserID, length: Int) -> Self {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == Commercial, HelixResponseType == Commercial
+{
+  public static func startCommercial(length: Int) -> Self {
     .init(
       method: "POST", path: "channels/commercial",
-      body: StartCommercialRequestBody(broadcasterID: channel, length: length))
+      body: { auth in
+        StartCommercialRequestBody(broadcasterID: auth.userID, length: length)
+      },
+      makeResponse: { result in
+        guard let response = result.data.first else {
+          throw HelixError.noDataInResponse
+        }
+
+        return response
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getExtensionAnalytics.swift
+++ b/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getExtensionAnalytics.swift
@@ -21,10 +21,7 @@ where
           ("first", limit.map(String.init)),
           ("after", cursor),
         ]
-      },
-      makeResponse: { result in
-        return (result.data, result.pagination?.cursor)
-      })
+      }, makeResponse: { ($0.data, $0.pagination?.cursor) })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getExtensionAnalytics.swift
+++ b/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getExtensionAnalytics.swift
@@ -14,12 +14,12 @@ where
       method: "GET", path: "analytics/extensions",
       queryItems: { _ in
         [
-          "extension_id": extensionID,
-          "type": type,
-          "started_at": range?.start.formatted(.iso8601),
-          "ended_at": range?.end.formatted(.iso8601),
-          "first": limit.map(String.init),
-          "after": cursor,
+          ("extension_id", extensionID),
+          ("type", type),
+          ("started_at", range?.start.formatted(.iso8601)),
+          ("ended_at", range?.end.formatted(.iso8601)),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
         ]
       },
       makeResponse: { result in

--- a/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getExtensionAnalytics.swift
+++ b/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getExtensionAnalytics.swift
@@ -1,19 +1,30 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<ExtensionReport> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([ExtensionReport], PaginationCursor?),
+  HelixResponseType == ExtensionReport
+{
   public static func getExtensionAnalytics(
     extensionID: String? = nil, type: String? = nil, range: DateInterval? = nil,
     limit: Int? = nil, after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("extension_id", extensionID),
-      ("type", type),
-      ("started_at", range?.start.formatted(.iso8601)),
-      ("ended_at", range?.end.formatted(.iso8601)),
-      ("first", limit.map(String.init)),
-      ("after", cursor))
-
-    return .init(method: "GET", path: "analytics/extensions", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "analytics/extensions",
+      queryItems: { _ in
+        [
+          "extension_id": extensionID,
+          "type": type,
+          "started_at": range?.start.formatted(.iso8601),
+          "ended_at": range?.end.formatted(.iso8601),
+          "first": limit.map(String.init),
+          "after": cursor,
+        ]
+      },
+      makeResponse: { result in
+        return (result.data, result.pagination?.cursor)
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getGameAnalytics.swift
+++ b/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getGameAnalytics.swift
@@ -1,19 +1,29 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<GameReport> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([GameReport], PaginationCursor?), HelixResponseType == GameReport
+{
   public static func getGameAnalytics(
     gameID: String? = nil, type: String? = nil, range: DateInterval? = nil,
     limit: Int? = nil, after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("game_id", gameID),
-      ("type", type),
-      ("started_at", range?.start.formatted(.iso8601)),
-      ("ended_at", range?.end.formatted(.iso8601)),
-      ("first", limit.map(String.init)),
-      ("after", cursor))
-
-    return .init(method: "GET", path: "analytics/games", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "analytics/games",
+      queryItems: { _ in
+        [
+          "game_id": gameID,
+          "type": type,
+          "started_at": range?.start.formatted(.iso8601),
+          "ended_at": range?.end.formatted(.iso8601),
+          "first": limit.map(String.init),
+          "after": cursor,
+        ]
+      },
+      makeResponse: { result in
+        return (result.data, result.pagination?.cursor)
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getGameAnalytics.swift
+++ b/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getGameAnalytics.swift
@@ -20,10 +20,7 @@ where
           ("first", limit.map(String.init)),
           ("after", cursor),
         ]
-      },
-      makeResponse: { result in
-        return (result.data, result.pagination?.cursor)
-      })
+      }, makeResponse: { ($0.data, $0.pagination?.cursor) })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getGameAnalytics.swift
+++ b/Sources/Twitch/Helix/Endpoints/Analytics/HelixEndpoint+getGameAnalytics.swift
@@ -13,12 +13,12 @@ where
       method: "GET", path: "analytics/games",
       queryItems: { _ in
         [
-          "game_id": gameID,
-          "type": type,
-          "started_at": range?.start.formatted(.iso8601),
-          "ended_at": range?.end.formatted(.iso8601),
-          "first": limit.map(String.init),
-          "after": cursor,
+          ("game_id", gameID),
+          ("type", type),
+          ("started_at", range?.start.formatted(.iso8601)),
+          ("ended_at", range?.end.formatted(.iso8601)),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
         ]
       },
       makeResponse: { result in

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannelEditors.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannelEditors.swift
@@ -10,10 +10,7 @@ where
       method: "GET", path: "channels/editors",
       queryItems: { auth in
         [("broadcaster_id", auth.userID)]
-      },
-      makeResponse: { result in
-        result.data
-      })
+      }, makeResponse: { $0.data })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannelEditors.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannelEditors.swift
@@ -1,10 +1,19 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Editor> {
-  public static func getChannelEditors(of channel: UserID) -> Self {
-    let queryItems = makeQueryItems(("broadcaster_id", channel))
-
-    return .init(method: "GET", path: "channels/editors", queryItems: queryItems)
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [Editor], HelixResponseType == Editor
+{
+  public static func getChannelEditors() -> Self {
+    return .init(
+      method: "GET", path: "channels/editors",
+      queryItems: { auth in
+        [("broadcaster_id", auth.userID)]
+      },
+      makeResponse: { result in
+        result.data
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannelFollowers.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannelFollowers.swift
@@ -42,10 +42,7 @@ where
       method: "GET", path: "channels/followers",
       queryItems: { auth in
         [("user_id", user), ("broadcaster_id", channelID ?? auth.userID)]
-      },
-      makeResponse: {
-        return $0.data.first
-      })
+      }, makeResponse: { $0.data.first })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannelFollowers.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannelFollowers.swift
@@ -3,7 +3,7 @@ import Foundation
 extension HelixEndpoint
 where
   EndpointResponseType == HelixEndpointResponseTypes.Normal,
-  ResponseType == ChannelFollowers, HelixResponseType == Follower
+  ResponseType == FollowerResponse, HelixResponseType == Follower
 {
   public static func getChannelFollowers(
     of channel: UserID? = nil, limit: Int? = nil, after cursor: String? = nil
@@ -22,7 +22,7 @@ where
           throw HelixError.missingDataInResponse
         }
 
-        return ChannelFollowers(
+        return FollowerResponse(
           total: total,
           followers: $0.data,
           cursor: $0.pagination?.cursor)
@@ -46,7 +46,7 @@ where
   }
 }
 
-public struct ChannelFollowers {
+public struct FollowerResponse {
   public let total: Int
 
   public let followers: [Follower]

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannels.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannels.swift
@@ -10,11 +10,7 @@ where
       method: "GET", path: "channels",
       queryItems: { _ in
         channels.map { ("broadcaster_id", $0) }
-      },
-      makeResponse: { result in
-        result.data
-      }
-    )
+      }, makeResponse: { $0.data })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannels.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getChannels.swift
@@ -1,10 +1,20 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Broadcaster> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [Broadcaster], HelixResponseType == Broadcaster
+{
   public static func getChannels(_ channels: [UserID]) -> Self {
-    let queryItems = channels.map { URLQueryItem(name: "broadcaster_id", value: $0) }
-
-    return .init(method: "GET", path: "channels", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "channels",
+      queryItems: { _ in
+        channels.map { ("broadcaster_id", $0) }
+      },
+      makeResponse: { result in
+        result.data
+      }
+    )
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getFollowedChannels.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getFollowedChannels.swift
@@ -41,9 +41,7 @@ where
       queryItems: { auth in
         [("user_id", auth.userID), ("broadcaster_id", channelID)]
       },
-      makeResponse: {
-        return $0.data.first
-      })
+      makeResponse: { $0.data.first })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getFollowedChannels.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getFollowedChannels.swift
@@ -3,7 +3,7 @@ import Foundation
 extension HelixEndpoint
 where
   EndpointResponseType == HelixEndpointResponseTypes.Normal,
-  ResponseType == FollowedChannels, HelixResponseType == Follow
+  ResponseType == FollowsResponse, HelixResponseType == Follow
 {
   public static func getFollowedChannels(limit: Int? = nil, after cursor: String? = nil)
     -> Self
@@ -22,7 +22,7 @@ where
           throw HelixError.missingDataInResponse
         }
 
-        return FollowedChannels(
+        return FollowsResponse(
           total: total,
           follows: $0.data,
           cursor: $0.pagination?.cursor)
@@ -45,7 +45,7 @@ where
   }
 }
 
-public struct FollowedChannels {
+public struct FollowsResponse {
   public let total: Int
 
   public let follows: [Follow]

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getFollowedChannels.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+getFollowedChannels.swift
@@ -1,27 +1,58 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Follow> {
-  public static func getFollowedChannels(
-    of user: UserID, limit: Int? = nil, after cursor: String? = nil
-  ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("user_id", user),
-      ("first", limit.map(String.init)),
-      ("after", cursor))
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == FollowedChannels, HelixResponseType == Follow
+{
+  public static func getFollowedChannels(limit: Int? = nil, after cursor: String? = nil)
+    -> Self
+  {
+    return .init(
+      method: "GET", path: "channels/followed",
+      queryItems: { auth in
+        [
+          ("user_id", auth.userID),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
+        ]
+      },
+      makeResponse: {
+        guard let total = $0.total else {
+          throw HelixError.missingDataInResponse
+        }
 
-    return .init(method: "GET", path: "channels/followed", queryItems: queryItems)
+        return FollowedChannels(
+          total: total,
+          follows: $0.data,
+          cursor: $0.pagination?.cursor)
+      })
   }
 }
 
-extension HelixEndpoint where Response == ResponseTypes.Optional<Follow> {
-  public static func checkFollow(from userID: String, to channelID: String) -> Self {
-    let queryItems = [
-      URLQueryItem(name: "user_id", value: userID),
-      URLQueryItem(name: "broadcaster_id", value: channelID),
-    ]
-
-    return .init(method: "GET", path: "channels/followed", queryItems: queryItems)
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == Follow?, HelixResponseType == Follow
+{
+  public static func checkFollow(to channelID: UserID) -> Self {
+    return .init(
+      method: "GET", path: "channels/followed",
+      queryItems: { auth in
+        [("user_id", auth.userID), ("broadcaster_id", channelID)]
+      },
+      makeResponse: {
+        return $0.data.first
+      })
   }
+}
+
+public struct FollowedChannels {
+  public let total: Int
+
+  public let follows: [Follow]
+
+  public let cursor: PaginationCursor?
 }
 
 public struct Follow: Decodable {

--- a/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+updateChannel.swift
+++ b/Sources/Twitch/Helix/Endpoints/Channels/HelixEndpoint+updateChannel.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func updateChannel(
-    _ channel: UserID,
     gameID: String? = nil,
     broadcasterLanguage: String? = nil,
     title: String? = nil,
@@ -16,19 +15,21 @@ extension HelixEndpoint where Response == ResponseTypes.Void {
         UpdateChannelRequestBody.Label(id: id.rawValue, isEnabled: isEnabled)
       }
 
-    let body = UpdateChannelRequestBody(
-      gameID: gameID,
-      broadcasterLanguage: broadcasterLanguage,
-      title: title,
-      delay: delay,
-      tags: tag,
-      contentClassificationLabels: contentClassificationLabels,
-      isBrandedContent: isBrandedContent)
-
-    let queryItems = makeQueryItems(("broadcaster_id", channel))
-
     return .init(
-      method: "PATCH", path: "channels", queryItems: queryItems, body: body)
+      method: "PATCH", path: "channels",
+      queryItems: { auth in
+        [("broadcaster_id", auth.userID)]
+      },
+      body: { _ in
+        UpdateChannelRequestBody(
+          gameID: gameID,
+          broadcasterLanguage: broadcasterLanguage,
+          title: title,
+          delay: delay,
+          tags: tag,
+          contentClassificationLabels: contentClassificationLabels,
+          isBrandedContent: isBrandedContent)
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getChannelBadges.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getChannelBadges.swift
@@ -1,10 +1,15 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<BadgeSet> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [BadgeSet], HelixResponseType == BadgeSet
+{
   public static func getChannelBadges(of channel: UserID) -> Self {
-    let queryItems = self.makeQueryItems(("broadcaster_id", channel))
-
-    return .init(method: "GET", path: "chat/badges", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "chat/badges",
+      queryItems: { _ in [("broadcaster_id", channel)] },
+      makeResponse: { $0.data })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getChannelEmotes.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getChannelEmotes.swift
@@ -1,11 +1,28 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<ChannelEmote> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ChannelEmotes, HelixResponseType == ChannelEmote
+{
   public static func getChannelEmotes(of channel: UserID) -> Self {
-    let queryItems = self.makeQueryItems(("broadcaster_id", channel))
+    return .init(
+      method: "GET", path: "chat/emotes",
+      queryItems: { _ in [("broadcaster_id", channel)] },
+      makeResponse: {
+        guard let template = $0.template else {
+          throw HelixError.missingDataInResponse
+        }
 
-    return .init(method: "GET", path: "chat/emotes", queryItems: queryItems)
+        return ChannelEmotes(emotes: $0.data, template: template)
+      })
   }
+}
+
+public struct ChannelEmotes {
+  public let emotes: [ChannelEmote]
+
+  public let template: String
 }
 
 public struct ChannelEmote: Decodable {

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getChatSettings.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getChatSettings.swift
@@ -1,14 +1,25 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Object<ChatSettings> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ChatSettings, HelixResponseType == ChatSettings
+{
   public static func getChatSettings(
     of channel: UserID, moderatorID: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID))
+    return .init(
+      method: "GET", path: "chat/settings",
+      queryItems: { _ in
+        [("broadcaster_id", channel), ("moderator_id", moderatorID)]
+      },
+      makeResponse: {
+        guard let settings = $0.data.first else {
+          throw HelixError.noDataInResponse
+        }
 
-    return .init(method: "GET", path: "chat/settings", queryItems: queryItems)
+        return settings
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getChatters.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getChatters.swift
@@ -1,20 +1,44 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Chatter> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == Chatters, HelixResponseType == Chatter
+{
   public static func getChatters(
     in channel: UserID,
-    moderatorID: String,
     limit: Int? = nil,
     after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID),
-      ("first", limit.map(String.init)),
-      ("after", cursor))
+    return .init(
+      method: "GET", path: "chat/chatters",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("moderator_id", auth.userID),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
+        ]
+      },
+      makeResponse: {
+        guard let total = $0.total else {
+          throw HelixError.missingDataInResponse
+        }
 
-    return .init(method: "GET", path: "chat/chatters", queryItems: queryItems)
+        return Chatters(
+          total: total,
+          chatters: $0.data,
+          cursor: $0.pagination?.cursor)
+      })
   }
+}
+
+public struct Chatters {
+  public let total: Int
+
+  public let chatters: [Chatter]
+
+  public let cursor: PaginationCursor?
 }
 
 public struct Chatter: Decodable {

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getEmoteSets.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getEmoteSets.swift
@@ -2,12 +2,33 @@ import Foundation
 
 public typealias EmoteSetID = String
 
-extension HelixEndpoint where Response == ResponseTypes.Array<SetEmote> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == EmoteSetResponse,
+  HelixResponseType == SetEmote
+{
   public static func getEmoteSets(_ sets: [EmoteSetID]) -> Self {
-    let queryItems = sets.map { URLQueryItem(name: "emote_set_id", value: $0) }
+    return .init(
+      method: "GET", path: "chat/emotes/set",
+      queryItems: { _ in
+        sets.map { ("emote_set_id", $0) }
+      },
+      makeResponse: {
+        guard let template = $0.template else {
+          throw HelixError.missingDataInResponse
+        }
 
-    return .init(method: "GET", path: "chat/emotes/set", queryItems: queryItems)
+        return EmoteSetResponse(emotes: $0.data, template: template)
+      }
+    )
   }
+}
+
+public struct EmoteSetResponse: Decodable {
+  public let emotes: [SetEmote]
+
+  public let template: String
 }
 
 public struct SetEmote: Decodable {

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getGlobalBadges.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getGlobalBadges.swift
@@ -1,7 +1,11 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<BadgeSet> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [BadgeSet], HelixResponseType == BadgeSet
+{
   public static func getGlobalBadges() -> Self {
-    return .init(method: "GET", path: "chat/badges/global")
+    return .init(method: "GET", path: "chat/badges/global", makeResponse: { $0.data })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getGlobalEmotes.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getGlobalEmotes.swift
@@ -1,9 +1,28 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<GlobalEmote> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == GlobalEmotes, HelixResponseType == GlobalEmote
+{
   public static func getGlobalEmotes() -> Self {
-    return .init(method: "GET", path: "chat/emotes/global")
+    return .init(
+      method: "GET", path: "chat/emotes/global",
+      makeResponse: {
+        guard let template = $0.template else {
+          throw HelixError.missingDataInResponse
+        }
+
+        return GlobalEmotes(emotes: $0.data, template: template)
+
+      })
   }
+}
+
+public struct GlobalEmotes {
+  public let emotes: [GlobalEmote]
+
+  public let template: String
 }
 
 public struct GlobalEmote: Decodable {

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getUserColor.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+getUserColor.swift
@@ -1,10 +1,17 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<UserColor> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [UserColor],
+  HelixResponseType == UserColor
+{
   public static func getUserColors(of users: [UserID]) -> Self {
-    let queryItems = users.map { URLQueryItem(name: "user_id", value: $0) }
-
-    return .init(method: "GET", path: "chat/color", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "chat/color",
+      queryItems: { _ in
+        users.map { ("user_id", $0) }
+      }, makeResponse: { $0.data })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+sendAnnouncement.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+sendAnnouncement.swift
@@ -1,22 +1,18 @@
 import Foundation
 
-// TODO: look into a way to maybe get rid of the `moderatorID` parameter
-// and use the authenticated user's ID instead
-
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func sendAnnouncement(
-    in channel: UserID, message: String, color: AnnouncementColor? = nil,
-    moderatorID: UserID
+    in channel: UserID, message: String, color: AnnouncementColor? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID))
-
     return .init(
-      method: "POST", path: "chat/announcements", queryItems: queryItems,
-      body: SendAnnouncementRequestBody(message: message, color: color))
+      method: "POST", path: "chat/announcements",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("moderator_id", auth.userID),
+        ]
+      }, body: { _ in SendAnnouncementRequestBody(message: message, color: color) })
   }
-
 }
 
 internal struct SendAnnouncementRequestBody: Encodable {

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+sendChatMessage.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+sendChatMessage.swift
@@ -1,15 +1,49 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ChatMessageResponse, HelixResponseType == ChatMessageResponse
+{
   public static func sendChatMessage(
-    in channel: UserID, as user: UserID, message: String,
+    in channel: UserID, message: String,
     replyParentMessageID: String? = nil
   ) -> Self {
     return .init(
       method: "POST", path: "chat/announcements",
-      body: SendChatMessageRequestBody(
-        broadcasterID: channel, senderID: user, message: message,
-        replyParentMessageID: replyParentMessageID))
+      body: { auth in
+        SendChatMessageRequestBody(
+          broadcasterID: channel,
+          senderID: auth.userID,
+          message: message,
+          replyParentMessageID: replyParentMessageID)
+      },
+      makeResponse: {
+        guard let messageResponse = $0.data.first else {
+          throw HelixError.noDataInResponse
+        }
+
+        return messageResponse
+      })
+  }
+}
+
+public struct ChatMessageResponse: Decodable {
+  public let messageID: String
+  public let isSent: Bool
+
+  public let dropReason: DropReason?
+
+  enum CodingKeys: String, CodingKey {
+    case messageID = "message_id"
+    case isSent = "is_sent"
+
+    case dropReason = "drop_reason"
+  }
+
+  public struct DropReason: Decodable {
+    let code: String
+    let message: String
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+sendShoutout.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+sendShoutout.swift
@@ -1,14 +1,17 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func sendShoutout(
-    from sendingUser: UserID, to receivingUser: UserID, moderatorID: String
+    from sendingUser: UserID, to receivingUser: UserID
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("from_broadcaster_id", sendingUser),
-      ("to_broadcaster_id", receivingUser),
-      ("moderator_id", moderatorID))
-
-    return .init(method: "POST", path: "chat/shoutouts", queryItems: queryItems)
+    return .init(
+      method: "POST", path: "chat/shoutouts",
+      queryItems: { auth in
+        [
+          ("from_broadcaster_id", sendingUser),
+          ("to_broadcaster_id", receivingUser),
+          ("moderator_id", auth.userID),
+        ]
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+updateUserColor.swift
+++ b/Sources/Twitch/Helix/Endpoints/Chat/HelixEndpoint+updateUserColor.swift
@@ -1,12 +1,15 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
-  public static func updateUserColor(of user: UserID, color: HelixColor) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("user_id", user),
-      ("color", color.rawValue))
-
-    return .init(method: "PUT", path: "chat/color", queryItems: queryItems)
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
+  public static func updateUserColor(to color: HelixColor) -> Self {
+    return .init(
+      method: "PUT", path: "chat/color",
+      queryItems: { auth in
+        [
+          ("user_id", auth.userID),
+          ("color", color.rawValue),
+        ]
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/ContentClassificationLabels/HelixEndpoint+getContentClassificationLabels.swift
+++ b/Sources/Twitch/Helix/Endpoints/ContentClassificationLabels/HelixEndpoint+getContentClassificationLabels.swift
@@ -1,12 +1,17 @@
 import Foundation
 
 extension HelixEndpoint
-where Response == ResponseTypes.Array<ContentClassificationLabel> {
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [ContentClassificationLabel],
+  HelixResponseType == ContentClassificationLabel
+{
   public static func getContentClassificationLabels(locale: String? = "en-US") -> Self {
-    let queryItems = self.makeQueryItems(("locale", locale))
-
     return .init(
-      method: "GET", path: "content_classification_labels", queryItems: queryItems)
+      method: "GET", path: "content_classification_labels",
+      queryItems: { _ in
+        [("locale", locale)]
+      }, makeResponse: { $0.data })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Games/HelixEndpoint+getGames.swift
+++ b/Sources/Twitch/Helix/Endpoints/Games/HelixEndpoint+getGames.swift
@@ -1,16 +1,26 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Game> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [Game],
+  HelixResponseType == Game
+{
   public static func getGames(
     gameIDs: [String] = [], names: [String] = [], igdbIDs: [String] = []
   ) -> Self {
-    let idQueryItems = gameIDs.map { URLQueryItem(name: "id", value: $0) }
-    let nameQueryItems = names.map { URLQueryItem(name: "name", value: $0) }
-    let igdbQueryItems = igdbIDs.map { URLQueryItem(name: "igdb_id", value: $0) }
+    let idQueryItems = gameIDs.map { ("id", $0) }
+    let nameQueryItems = names.map { ("name", $0) }
+    let igdbQueryItems = igdbIDs.map { ("igdb_id", $0) }
 
-    let queryItems = idQueryItems + nameQueryItems + igdbQueryItems
-
-    return .init(method: "GET", path: "games", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "games",
+      queryItems: { _ in
+        idQueryItems + nameQueryItems + igdbQueryItems
+      },
+      makeResponse: {
+        $0.data
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Games/HelixEndpoint+getTopGames.swift
+++ b/Sources/Twitch/Helix/Endpoints/Games/HelixEndpoint+getTopGames.swift
@@ -1,14 +1,22 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Game> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([Game], PaginationCursor?),
+  HelixResponseType == Game
+{
   public static func getTopGames(
     limit: Int? = nil, after startCursor: String? = nil, before endCursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("after", startCursor),
-      ("before", endCursor),
-      ("first", limit.map(String.init)))
-
-    return .init(method: "GET", path: "games/top", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "games/top",
+      queryItems: { _ in
+        [
+          ("after", startCursor),
+          ("before", endCursor),
+          ("first", limit.map(String.init)),
+        ]
+      }, makeResponse: { ($0.data, $0.pagination?.cursor) })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+addChannelModerator.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+addChannelModerator.swift
@@ -1,13 +1,14 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
-  public static func addChannelModerator(
-    in channel: String, userID: String
-  ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("user_id", userID))
-
-    return .init(method: "POST", path: "moderation/moderators", queryItems: queryItems)
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
+  public static func addChannelModerator(userID: String) -> Self {
+    return .init(
+      method: "POST", path: "moderation/moderators",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", auth.userID),
+          ("user_id", userID),
+        ]
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+addChannelVIP.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+addChannelVIP.swift
@@ -1,13 +1,16 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func addChannelVIP(
     in channel: String, userID: String
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("user_id", userID))
-
-    return .init(method: "POST", path: "channels/vips", queryItems: queryItems)
+    return .init(
+      method: "POST", path: "channels/vips",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", auth.userID),
+          ("user_id", userID),
+        ]
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+addChannelVIP.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+addChannelVIP.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
-  public static func addChannelVIP(
-    in channel: String, userID: String
-  ) -> Self {
+  public static func addChannelVIP(userID: String) -> Self {
     return .init(
       method: "POST", path: "channels/vips",
       queryItems: { auth in

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+checkAutomodStatus.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+checkAutomodStatus.swift
@@ -1,20 +1,32 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<AutomodStatus> {
-  public static func checkAutomodStatus(
-    in channel: UserID, messages: (id: String, message: String)...
-  ) -> Self {
-    return self.checkAutomodStatus(in: channel, messages: messages)
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [AutomodStatus], HelixResponseType == AutomodStatus
+{
+  public static func checkAutomodStatus(messages: (id: String, message: String)...)
+    -> Self
+  {
+    return self.checkAutomodStatus(messages: messages)
   }
 
-  public static func checkAutomodStatus(
-    in channel: String, messages: [(id: String, message: String)]
-  ) -> Self {
-    let queryItems = self.makeQueryItems(("broadcaster_id", channel))
+  public static func checkAutomodStatus(messages: [(id: String, message: String)]) -> Self
+  {
 
     return .init(
-      method: "POST", path: "moderation/enforcements/status", queryItems: queryItems,
-      body: ["data": messages.map { ["msg_id": $0.id, "msg_text": $0.message] }])
+      method: "POST", path: "moderation/enforcements/status",
+      queryItems: { auth in
+        [("broadcaster_id", auth.userID)]
+      },
+      body: { _ in
+        [
+          "data": messages.map {
+            ["msg_id": $0.id, "msg_text": $0.message]
+          }
+        ]
+      },
+      makeResponse: { $0.data })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+deleteChatMessage.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+deleteChatMessage.swift
@@ -1,14 +1,17 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func deleteChatMessage(
-    in channel: UserID, messageID: String, moderatorID: String
+    in channel: UserID, messageID: String
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID),
-      ("message_id", messageID))
-
-    return .init(method: "DELETE", path: "moderation/chat", queryItems: queryItems)
+    return .init(
+      method: "DELETE", path: "moderation/chat",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("moderator_id", auth.userID),
+          ("message_id", messageID),
+        ]
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getAutomodSettings.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getAutomodSettings.swift
@@ -1,15 +1,26 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Object<AutomodSettings> {
-  public static func getAutomodSettings(
-    of channel: UserID, moderatorID: String
-  ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID))
-
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == AutomodSettings, HelixResponseType == AutomodSettings
+{
+  public static func getAutomodSettings(of channel: UserID) -> Self {
     return .init(
-      method: "GET", path: "moderation/automod/settings", queryItems: queryItems)
+      method: "GET", path: "moderation/automod/settings",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("moderator_id", auth.userID),
+        ]
+      },
+      makeResponse: {
+        guard let settings = $0.data.first else {
+          throw HelixError.noDataInResponse
+        }
+
+        return settings
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getBlockedTerms.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getBlockedTerms.swift
@@ -1,19 +1,28 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<BlockedTerm> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([BlockedTerm], PaginationCursor?), HelixResponseType == BlockedTerm
+{
   public static func getBlockedTerms(
     in channel: UserID,
     limit: Int? = nil,
-    after cursor: String? = nil,
-    moderatorID: String
+    after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID),
-      ("first", limit.map(String.init)),
-      ("after", cursor))
-
-    return .init(method: "GET", path: "moderation/blocked_terms", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "moderation/blocked_terms",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("moderator_id", auth.userID),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
+        ]
+      },
+      makeResponse: {
+        ($0.data, $0.pagination?.cursor)
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getModeratedChannels.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getModeratedChannels.swift
@@ -1,15 +1,24 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<ModeratedChannel> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([ModeratedChannel], PaginationCursor?),
+  HelixResponseType == ModeratedChannel
+{
   public static func getModeratedChannels(
-    of user: UserID, limit: Int? = nil, after cursor: String? = nil
+    limit: Int? = nil, after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("user_id", user),
-      ("first", limit.map(String.init)),
-      ("after", cursor))
-
-    return .init(method: "GET", path: "moderation/channels", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "moderation/channels",
+      queryItems: { auth in
+        [
+          ("user_id", auth.userID),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
+        ]
+      }, makeResponse: { ($0.data, $0.pagination?.cursor) }
+    )
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getModerators.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getModerators.swift
@@ -1,22 +1,24 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Moderator> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([Moderator], PaginationCursor?), HelixResponseType == Moderator
+{
   public static func getModerators(
-    of channel: String,
     filterUserIDs: [String] = [],
     limit: Int? = nil,
     after startCursor: String? = nil
   ) -> Self {
-    var queryItems =
-      self.makeQueryItems(
-        ("broadcaster_id", channel),
-        ("first", limit.map(String.init)),
-        ("after", startCursor)) ?? []
-
-    queryItems.append(
-      contentsOf: filterUserIDs.compactMap { URLQueryItem(name: "user_id", value: $0) })
-
-    return .init(method: "GET", path: "moderation/moderators", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "moderation/moderators",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", auth.userID),
+          ("first", limit.map(String.init)),
+          ("after", startCursor),
+        ] + filterUserIDs.map { ("user_id", $0) }
+      }, makeResponse: { ($0.data, $0.pagination?.cursor) })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getShieldModeStatus.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+getShieldModeStatus.swift
@@ -1,15 +1,28 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Object<ShieldModeStatus> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ShieldModeStatus, HelixResponseType == ShieldModeStatus
+{
   public static func getShieldModeStatus(
-    of channel: UserID, moderatorID: String
+    of channel: UserID
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID))
-
     return .init(
-      method: "GET", path: "moderation/shield_mode", queryItems: queryItems)
+      method: "GET", path: "moderation/shield_mode",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("moderator_id", auth.userID),
+        ]
+      },
+      makeResponse: {
+        guard let status = $0.data.first else {
+          throw HelixError.noDataInResponse
+        }
+
+        return status
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+handleAutomodMessage.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+handleAutomodMessage.swift
@@ -1,26 +1,20 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
-  private static func handleAutomodMessage(
-    messageID: String, action: String, moderatorID: String
-  ) -> Self {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
+  private static func handleAutomodMessage(messageID: String, action: String) -> Self {
     .init(
       method: "POST", path: "moderation/automod/message",
-      body: ["data": ["user_id": moderatorID, "msg_id": messageID, "action": action]]
+      body: { auth in
+        ["data": ["user_id": auth.userID, "msg_id": messageID, "action": action]]
+      }
     )
   }
 
-  public static func approveAutomodMessage(
-    messageID: String, moderatorID: String
-  ) -> Self {
-    self.handleAutomodMessage(
-      messageID: messageID, action: "APPROVE", moderatorID: moderatorID)
+  public static func approveAutomodMessage(messageID: String) -> Self {
+    self.handleAutomodMessage(messageID: messageID, action: "APPROVE")
   }
 
-  public static func denyAutomodMessage(
-    messageID: String, moderatorID: String
-  ) -> Self {
-    self.handleAutomodMessage(
-      messageID: messageID, action: "DENY", moderatorID: moderatorID)
+  public static func denyAutomodMessage(messageID: String) -> Self {
+    self.handleAutomodMessage(messageID: messageID, action: "DENY")
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+removeBlockedTerm.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+removeBlockedTerm.swift
@@ -1,15 +1,17 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func removeBlockedTerm(
-    in channel: UserID, termID: String, moderatorID: String
+    in channel: UserID, termID: String
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID),
-      ("id", termID))
-
     return .init(
-      method: "DELETE", path: "moderation/blocked_terms", queryItems: queryItems)
+      method: "DELETE", path: "moderation/blocked_terms",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("moderator_id", auth.userID),
+          ("id", termID),
+        ]
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+removeChannelModerator.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+removeChannelModerator.swift
@@ -1,13 +1,14 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
-  public static func removeChannelModerator(
-    in channel: UserID, userID: String
-  ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("user_id", userID))
-
-    return .init(method: "DELETE", path: "moderation/moderators", queryItems: queryItems)
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
+  public static func removeChannelModerator(userID: String) -> Self {
+    return .init(
+      method: "DELETE", path: "moderation/moderators",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", auth.userID),
+          ("user_id", userID),
+        ]
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+removeChannelVIP.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+removeChannelVIP.swift
@@ -1,13 +1,14 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
-  public static func removeChannelVIP(
-    in channel: UserID, userID: String
-  ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("user_id", userID))
-
-    return .init(method: "DELETE", path: "channels/vips", queryItems: queryItems)
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
+  public static func removeChannelVIP(userID: String) -> Self {
+    return .init(
+      method: "DELETE", path: "channels/vips",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", auth.userID),
+          ("user_id", userID),
+        ]
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+unbanUser.swift
+++ b/Sources/Twitch/Helix/Endpoints/Moderation/HelixEndpoint+unbanUser.swift
@@ -1,14 +1,17 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func unbanUser(
-    _ user: UserID, in channel: UserID, moderatorID: String
+    _ user: UserID, in channel: UserID
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", channel),
-      ("moderator_id", moderatorID),
-      ("user_id", user))
-
-    return .init(method: "DELETE", path: "moderation/bans", queryItems: queryItems)
+    return .init(
+      method: "DELETE", path: "moderation/bans",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("moderator_id", auth.userID),
+          ("user_id", user),
+        ]
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Search/HelixEndpoint+searchCategories.swift
+++ b/Sources/Twitch/Helix/Endpoints/Search/HelixEndpoint+searchCategories.swift
@@ -1,15 +1,26 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Category> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([Category], PaginationCursor?),
+  HelixResponseType == Category
+{
   public static func searchCategories(
     for searchQuery: String, limit: Int? = nil, after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("query", searchQuery),
-      ("after", cursor),
-      ("first", limit.map(String.init)))
-
-    return .init(method: "GET", path: "search/categories", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "search/categories",
+      queryItems: { _ in
+        [
+          ("query", searchQuery),
+          ("after", cursor),
+          ("first", limit.map(String.init)),
+        ]
+      },
+      makeResponse: {
+        ($0.data, $0.pagination?.cursor)
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Search/HelixEndpoint+searchChannels.swift
+++ b/Sources/Twitch/Helix/Endpoints/Search/HelixEndpoint+searchChannels.swift
@@ -1,19 +1,29 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Channel> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([Channel], PaginationCursor?), HelixResponseType == Channel
+{
   public static func searchChannels(
     for searchQuery: String,
     liveOnly: Bool? = nil,
     limit: Int? = nil,
     after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("query", searchQuery),
-      ("live_only", liveOnly.map(String.init)),
-      ("after", cursor),
-      ("first", limit.map(String.init)))
-
-    return .init(method: "GET", path: "search/channels", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "search/channels",
+      queryItems: { _ in
+        [
+          ("query", searchQuery),
+          ("live_only", liveOnly.map(String.init)),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
+        ]
+      },
+      makeResponse: {
+        ($0.data, $0.pagination?.cursor)
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Streams/HelixEndpoint+getFollowedStreams.swift
+++ b/Sources/Twitch/Helix/Endpoints/Streams/HelixEndpoint+getFollowedStreams.swift
@@ -1,14 +1,22 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<Stream> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == ([Stream], PaginationCursor?),
+  HelixResponseType == Stream
+{
   public static func getFollowedStreams(
-    of user: UserID, limit: Int? = nil, after cursor: String? = nil
+    limit: Int? = nil, after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("user_id", user),
-      ("first", limit.map(String.init)),
-      ("after", cursor))
-
-    return .init(method: "GET", path: "streams/followed", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "streams/followed",
+      queryItems: { auth in
+        [
+          ("user_id", auth.userID),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
+        ]
+      }, makeResponse: { ($0.data, $0.pagination?.cursor) })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Subscriptions/HelixEndpoint+checkSubscription.swift
+++ b/Sources/Twitch/Helix/Endpoints/Subscriptions/HelixEndpoint+checkSubscription.swift
@@ -1,15 +1,23 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Optional<Subscription> {
-  public static func checkSubscription(
-    of user: UserID, to channel: UserID
-  ) -> Self {
-    let queryItems = [
-      URLQueryItem(name: "broadcaster_id", value: channel),
-      URLQueryItem(name: "user_id", value: user),
-    ]
-
-    return .init(method: "GET", path: "subscriptions/user", queryItems: queryItems)
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == Subscription?,
+  HelixResponseType == Subscription
+{
+  public static func checkSubscription(to channel: UserID) -> Self {
+    return .init(
+      method: "GET", path: "subscriptions/user",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", channel),
+          ("user_id", auth.userID),
+        ]
+      },
+      makeResponse: { response in
+        return response.data.first
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+blockUser.swift
+++ b/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+blockUser.swift
@@ -1,15 +1,18 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func block(
     _ user: UserID, sourceContext: SourceContext? = nil, reason: Reason? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("target_user_id", user),
-      ("source_context", sourceContext?.rawValue),
-      ("reason", reason?.rawValue))
-
-    return .init(method: "PUT", path: "users/blocks", queryItems: queryItems)
+    return .init(
+      method: "PUT", path: "users/blocks",
+      queryItems: { _ in
+        [
+          ("target_user_id", user),
+          ("source_context", sourceContext?.rawValue),
+          ("reason", reason?.rawValue),
+        ]
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+getUserBlocklist.swift
+++ b/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+getUserBlocklist.swift
@@ -1,15 +1,25 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<BlockedUser> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [BlockedUser], HelixResponseType == BlockedUser
+{
   public static func getBlocklist(
-    of user: UserID, limit: Int? = nil, after cursor: String? = nil
+    limit: Int? = nil, after cursor: String? = nil
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("broadcaster_id", user),
-      ("first", limit.map(String.init)),
-      ("after", cursor))
-
-    return .init(method: "GET", path: "users/blocks", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "users/blocks",
+      queryItems: { auth in
+        [
+          ("broadcaster_id", auth.userID),
+          ("first", limit.map(String.init)),
+          ("after", cursor),
+        ]
+      },
+      makeResponse: {
+        $0.data
+      })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+getUsers.swift
+++ b/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+getUsers.swift
@@ -1,15 +1,18 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Array<User> {
-  public static func getUsers(
-    ids: [UserID] = [], names: [String] = []
-  ) -> Self {
-    let idQueryItems = ids.map { URLQueryItem(name: "id", value: $0) }
-    let loginQueryItems = names.map { URLQueryItem(name: "login", value: $0) }
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == [User], HelixResponseType == User
+{
+  public static func getUsers(ids: [UserID] = [], names: [String] = []) -> Self {
+    let idQueryItems = ids.map { ("id", $0) }
+    let loginQueryItems = names.map { ("login", $0) }
 
-    let queryItems = idQueryItems + loginQueryItems
-
-    return .init(method: "GET", path: "users", queryItems: queryItems)
+    return .init(
+      method: "GET", path: "users",
+      queryItems: { _ in idQueryItems + loginQueryItems },
+      makeResponse: { $0.data })
   }
 }
 

--- a/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+unblockUser.swift
+++ b/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+unblockUser.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func unblock(_ user: UserID) -> Self {
-    let queryItems = self.makeQueryItems(("target_user_id", user))
-
-    return .init(method: "DELETE", path: "users/blocks", queryItems: queryItems)
+    return .init(
+      method: "DELETE", path: "users/blocks",
+      queryItems: { _ in [("target_user_id", user)] })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+updateUser.swift
+++ b/Sources/Twitch/Helix/Endpoints/Users/HelixEndpoint+updateUser.swift
@@ -1,9 +1,22 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Object<User> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == User, HelixResponseType == User
+{
   public static func updateUser(description: String) -> Self {
-    let queryItems = self.makeQueryItems(("description", description))
+    return .init(
+      method: "PUT", path: "users",
+      queryItems: { _ in
+        [("description", description)]
+      },
+      makeResponse: {
+        guard let user = $0.data.first else {
+          throw HelixError.noDataInResponse
+        }
 
-    return .init(method: "PUT", path: "users", queryItems: queryItems)
+        return user
+      })
   }
 }

--- a/Sources/Twitch/Helix/Endpoints/Whispers/HelixEndpoint+sendWhisper.swift
+++ b/Sources/Twitch/Helix/Endpoints/Whispers/HelixEndpoint+sendWhisper.swift
@@ -1,16 +1,18 @@
 import Foundation
 
-extension HelixEndpoint where Response == ResponseTypes.Void {
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
   public static func sendWhisper(
-    from sender: UserID, to receiver: UserID, message: String
+    to receiver: UserID, message: String
   ) -> Self {
-    let queryItems = self.makeQueryItems(
-      ("from_user_id", sender),
-      ("to_user_id", receiver))
-
     return .init(
-      method: "POST", path: "whispers", queryItems: queryItems,
-      body: Whisper(message: message))
+      method: "POST", path: "whispers",
+      queryItems: { auth in
+        [
+          ("from_user_id", auth.userID),
+          ("to_user_id", receiver),
+        ]
+      },
+      body: { _ in Whisper(message: message) })
   }
 }
 

--- a/Sources/Twitch/Helix/HelixEndpoint.swift
+++ b/Sources/Twitch/Helix/HelixEndpoint.swift
@@ -70,9 +70,9 @@ public struct HelixEndpoint<
 }
 
 extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
-  private init(
+  internal init(
     method: String, path: String,
-    queryItems: @escaping (TwitchCredentials) -> [String: String?] = { _ in [:] },
+    queryItems: @escaping (TwitchCredentials) -> [(String, String?)] = { _ in [] },
     body: @escaping (TwitchCredentials) -> Encodable? = { _ in nil }
   ) {
     // makeResponse should never be called on a Void endpoint!

--- a/Sources/Twitch/Helix/HelixEndpoint.swift
+++ b/Sources/Twitch/Helix/HelixEndpoint.swift
@@ -13,13 +13,13 @@ public struct HelixEndpoint<
   private let method: String
   private let path: String
 
-  private let makeQueryItems: (TwitchCredentials) -> [String: String?]
+  private let makeQueryItems: (TwitchCredentials) -> [(String, String?)]
   private let makeBody: (TwitchCredentials) -> Encodable?
   private let makeResponse: (HelixResponse<HelixResponseType>) throws -> ResponseType
 
   internal init(
     method: String, path: String,
-    queryItems: @escaping (TwitchCredentials) -> [String: String?] = { _ in [:] },
+    queryItems: @escaping (TwitchCredentials) -> [(String, String?)] = { _ in [] },
     body: @escaping (TwitchCredentials) -> Encodable? = { _ in nil },
     makeResponse: @escaping (HelixResponse<HelixResponseType>) throws -> ResponseType
   ) {
@@ -36,11 +36,11 @@ public struct HelixEndpoint<
   internal func makeRequest(using authentication: TwitchCredentials) -> URLRequest {
     var urlComponents = URLComponents(string: path)
 
-    let queryItems: [URLQueryItem] =
-      makeQueryItems(authentication).compactMap({ pair in
-        guard let value = pair.value else { return nil }
-        return URLQueryItem(name: pair.key, value: value)
-      })
+    let queryItems =
+      makeQueryItems(authentication).compactMap { (key, value) in
+        guard let value else { return nil }
+        return URLQueryItem(name: key, value: value)
+      } as [URLQueryItem]
 
     urlComponents?.queryItems = !queryItems.isEmpty ? queryItems : nil
 

--- a/Sources/Twitch/Helix/HelixEndpoint.swift
+++ b/Sources/Twitch/Helix/HelixEndpoint.swift
@@ -91,3 +91,4 @@ public enum HelixEndpointResponseTypes {
 public struct VoidResponse: Decodable {}
 
 public typealias UserID = String
+public typealias PaginationCursor = String

--- a/Sources/Twitch/Helix/HelixEndpoint.swift
+++ b/Sources/Twitch/Helix/HelixEndpoint.swift
@@ -4,17 +4,45 @@ import Foundation
   import FoundationNetworking
 #endif
 
-public struct HelixEndpoint<Response: ResponseType> {
+public struct HelixEndpoint<
+  ResponseType: Decodable, HelixResponseType: Decodable,
+  EndpointResponseType: HelixEndpointResponseType
+> {
   private let baseURL = URL(string: "https://api.twitch.tv/helix")!
 
   private let method: String
   private let path: String
-  private let queryItems: [URLQueryItem]?
-  private let body: Encodable?
+
+  private let makeQueryItems: (TwitchCredentials) -> [String: String?]
+  private let makeBody: (TwitchCredentials) -> Encodable?
+  private let makeResponse: (HelixResponse<HelixResponseType>) throws -> ResponseType
+
+  internal init(
+    method: String, path: String,
+    queryItems: @escaping (TwitchCredentials) -> [String: String?] = { _ in [:] },
+    body: @escaping (TwitchCredentials) -> Encodable? = { _ in nil },
+    makeResponse: @escaping (HelixResponse<HelixResponseType>) throws -> ResponseType
+  ) {
+    self.method = method
+
+    // TODO: fix the URLComponents assembly to not require this
+    self.path = "helix/" + path
+
+    self.makeQueryItems = queryItems
+    self.makeBody = body
+    self.makeResponse = makeResponse
+  }
 
   internal func makeRequest(using authentication: TwitchCredentials) -> URLRequest {
     var urlComponents = URLComponents(string: path)
-    urlComponents?.queryItems = queryItems
+
+    let queryItems: [URLQueryItem] =
+      makeQueryItems(authentication).compactMap({ pair in
+        guard let value = pair.value else { return nil }
+        return URLQueryItem(name: pair.key, value: value)
+      })
+
+    urlComponents?.queryItems = !queryItems.isEmpty ? queryItems : nil
 
     let url = urlComponents?.url(relativeTo: baseURL)
     guard let url else { fatalError("Invalid URL") }
@@ -26,7 +54,7 @@ public struct HelixEndpoint<Response: ResponseType> {
       urlRequest.addValue(value, forHTTPHeaderField: key)
     })
 
-    if let body {
+    if let body = makeBody(authentication) {
       urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
       urlRequest.httpBody = try? JSONEncoder().encode(body)
     }
@@ -34,35 +62,32 @@ public struct HelixEndpoint<Response: ResponseType> {
     return urlRequest
   }
 
-  internal init(
-    method: String, path: String, queryItems: [URLQueryItem]? = nil,
-    body: Encodable? = nil
+  internal func makeResponse(from response: HelixResponse<HelixResponseType>) throws
+    -> ResponseType
+  {
+    try makeResponse(response)
+  }
+}
+
+extension HelixEndpoint where EndpointResponseType == HelixEndpointResponseTypes.Void {
+  private init(
+    method: String, path: String,
+    queryItems: @escaping (TwitchCredentials) -> [String: String?] = { _ in [:] },
+    body: @escaping (TwitchCredentials) -> Encodable? = { _ in nil }
   ) {
-    self.method = method
-
-    // TODO: fix the URLComponents assembly to not require this
-    self.path = "helix/" + path
-
-    self.queryItems = queryItems
-    self.body = body
-  }
-
-  internal static func makeQueryItems(_ items: (String, String?)...) -> [URLQueryItem]? {
-    let queryItems: [URLQueryItem] = items.compactMap({ key, value in
-      guard let value = value else { return nil }
-      return URLQueryItem(name: key, value: value)
-    })
-
-    return queryItems.isEmpty ? nil : queryItems
+    // makeResponse should never be called on a Void endpoint!
+    self.init(
+      method: method, path: path, queryItems: queryItems, body: body,
+      makeResponse: { _ in fatalError() })
   }
 }
 
-public protocol ResponseType {}
-public enum ResponseTypes {
-  public enum Void: ResponseType {}
-  public enum Array<R: Decodable>: ResponseType {}
-  public enum Object<R: Decodable>: ResponseType {}
-  public enum Optional<R: Decodable>: ResponseType {}
+public protocol HelixEndpointResponseType {}
+public enum HelixEndpointResponseTypes {
+  public enum Void: HelixEndpointResponseType {}
+  public enum Normal: HelixEndpointResponseType {}
 }
+
+public struct VoidResponse: Decodable {}
 
 public typealias UserID = String

--- a/Sources/Twitch/Helix/HelixEndpoint.swift
+++ b/Sources/Twitch/Helix/HelixEndpoint.swift
@@ -5,7 +5,7 @@ import Foundation
 #endif
 
 public struct HelixEndpoint<
-  ResponseType: Decodable, HelixResponseType: Decodable,
+  ResponseType, HelixResponseType: Decodable,
   EndpointResponseType: HelixEndpointResponseType
 > {
   private let baseURL = URL(string: "https://api.twitch.tv/helix")!

--- a/Sources/Twitch/Helix/HelixEndpoint.swift
+++ b/Sources/Twitch/Helix/HelixEndpoint.swift
@@ -88,7 +88,5 @@ public enum HelixEndpointResponseTypes {
   public enum Normal: HelixEndpointResponseType {}
 }
 
-public struct VoidResponse: Decodable {}
-
 public typealias UserID = String
 public typealias PaginationCursor = String

--- a/Sources/Twitch/Helix/HelixError.swift
+++ b/Sources/Twitch/Helix/HelixError.swift
@@ -6,6 +6,7 @@ public enum HelixError: Error {
   case parsingErrorFailed(status: Int, rawResponse: String)
 
   case noDataInResponse
+  case missingDataInResponse
 
   case nonEmptyResponse(rawResponse: String)
 }

--- a/Sources/Twitch/Helix/HelixError.swift
+++ b/Sources/Twitch/Helix/HelixError.swift
@@ -5,5 +5,7 @@ public enum HelixError: Error {
   case parsingResponseFailed(rawResponse: String)
   case parsingErrorFailed(status: Int, rawResponse: String)
 
+  case noDataInResponse
+
   case nonEmptyResponse(rawResponse: String)
 }

--- a/Sources/Twitch/Helix/HelixResponse.swift
+++ b/Sources/Twitch/Helix/HelixResponse.swift
@@ -29,3 +29,5 @@ internal struct HelixErrorResponse: Decodable {
   let status: Int
   let message: String
 }
+
+public struct EmptyResponse: Decodable {}

--- a/Sources/Twitch/Helix/HelixResponse.swift
+++ b/Sources/Twitch/Helix/HelixResponse.swift
@@ -6,6 +6,21 @@ internal struct HelixResponse<T: Decodable>: Decodable {
   let points: Int?
   let template: String?
 
+  let cost: Int?
+  let totalCost: Int?
+  let maxTotalCost: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case data
+    case pagination
+    case total
+    case points
+    case template
+    case cost
+    case totalCost = "total_cost"
+    case maxTotalCost = "max_total_cost"
+  }
+
   internal struct Pagination: Decodable { let cursor: String? }
 }
 

--- a/Sources/Twitch/Helix/HelixResponse.swift
+++ b/Sources/Twitch/Helix/HelixResponse.swift
@@ -1,4 +1,4 @@
-public struct HelixResponse<T: Decodable>: Decodable {
+internal struct HelixResponse<T: Decodable>: Decodable {
   let data: [T]
 
   let pagination: Pagination?

--- a/Sources/Twitch/Helix/TwitchClient+Helix.swift
+++ b/Sources/Twitch/Helix/TwitchClient+Helix.swift
@@ -12,7 +12,7 @@ extension TwitchClient {
   // MARK: - Async methods
 
   public func request(
-    endpoint: HelixEndpoint<VoidResponse, VoidResponse, HelixEndpointResponseTypes.Void>
+    endpoint: HelixEndpoint<some Any, some Any, HelixEndpointResponseTypes.Void>
   )
     async throws
   {
@@ -39,9 +39,7 @@ extension TwitchClient {
   // MARK: - Callback methods
 
   public func requestTask(
-    for endpoint: HelixEndpoint<
-      VoidResponse, VoidResponse, HelixEndpointResponseTypes.Void
-    >,
+    for endpoint: HelixEndpoint<some Any, some Any, HelixEndpointResponseTypes.Void>,
     completionHandler: @escaping @Sendable (HelixError?) -> Void
   ) {
     Task {
@@ -73,9 +71,7 @@ extension TwitchClient {
   #if canImport(Combine)
 
     public func requestPublisher(
-      for endpoint: HelixEndpoint<
-        VoidResponse, VoidResponse, HelixEndpointResponseTypes.Void
-      >
+      for endpoint: HelixEndpoint<some Any, some Any, HelixEndpointResponseTypes.Void>
     ) -> AnyPublisher<Void, HelixError> {
       return Future { promise in
         Task {

--- a/Sources/Twitch/Helix/TwitchClient+Helix.swift
+++ b/Sources/Twitch/Helix/TwitchClient+Helix.swift
@@ -24,7 +24,7 @@ extension TwitchClient {
     }
   }
 
-  public func request<R: Decodable, H: Decodable>(
+  public func request<R, H: Decodable>(
     endpoint: HelixEndpoint<R, H, HelixEndpointResponseTypes.Normal>
   )
     async throws
@@ -54,7 +54,7 @@ extension TwitchClient {
     }
   }
 
-  public func requestTask<R: Decodable, H: Decodable>(
+  public func requestTask<R, H: Decodable>(
     for endpoint: HelixEndpoint<R, H, HelixEndpointResponseTypes.Normal>,
     completionHandler: @escaping @Sendable (R?, HelixError?) -> Void
   ) {
@@ -89,7 +89,7 @@ extension TwitchClient {
       }.eraseToAnyPublisher()
     }
 
-    public func requestPublisher<R: Decodable, H: Decodable>(
+    public func requestPublisher<R, H: Decodable>(
       for endpoint: HelixEndpoint<R, H, HelixEndpointResponseTypes.Normal>
     ) -> AnyPublisher<R, HelixError> {
       return Future { promise in
@@ -109,12 +109,8 @@ extension TwitchClient {
   // MARK: - Networking implementation
 
   private func data(
-    for endpoint: HelixEndpoint<
-      some Decodable, some Decodable, some HelixEndpointResponseType
-    >
-  )
-    async throws -> Data
-  {
+    for endpoint: HelixEndpoint<some Any, some Decodable, some HelixEndpointResponseType>
+  ) async throws -> Data {
     let request = endpoint.makeRequest(using: self.authentication)
 
     let (data, response): (Data, URLResponse)

--- a/Sources/Twitch/Helix/TwitchClient+Helix.swift
+++ b/Sources/Twitch/Helix/TwitchClient+Helix.swift
@@ -11,7 +11,11 @@ import Foundation
 extension TwitchClient {
   // MARK: - Async methods
 
-  public func request(endpoint: HelixEndpoint<ResponseTypes.Void>) async throws {
+  public func request(
+    endpoint: HelixEndpoint<VoidResponse, VoidResponse, HelixEndpointResponseTypes.Void>
+  )
+    async throws
+  {
     let data = try await self.data(for: endpoint)
 
     guard data.isEmpty else {
@@ -20,41 +24,24 @@ extension TwitchClient {
     }
   }
 
-  public func request<R>(endpoint: HelixEndpoint<ResponseTypes.Array<R>>) async throws
-    -> HelixResponse<R>
-  {
-    let data = try await self.data(for: endpoint)
-
-    return try self.decode(data)
-  }
-
-  public func request<R>(endpoint: HelixEndpoint<ResponseTypes.Object<R>>) async throws
+  public func request<R: Decodable, H: Decodable>(
+    endpoint: HelixEndpoint<R, H, HelixEndpointResponseTypes.Normal>
+  )
+    async throws
     -> R
   {
     let data = try await self.data(for: endpoint)
-    let response = try self.decode(data) as HelixResponse<R>
+    let response = try self.decode(data) as HelixResponse<H>
 
-    guard let result = response.data.first else {
-      let rawResponse = String(decoding: data, as: UTF8.self)
-      throw HelixError.parsingResponseFailed(rawResponse: rawResponse)
-    }
-
-    return result
-  }
-
-  public func request<R>(endpoint: HelixEndpoint<ResponseTypes.Optional<R>>) async throws
-    -> R?
-  {
-    let data = try await self.data(for: endpoint)
-    let response = try self.decode(data) as HelixResponse<R>
-
-    return response.data.first
+    return try endpoint.makeResponse(from: response)
   }
 
   // MARK: - Callback methods
 
   public func requestTask(
-    for endpoint: HelixEndpoint<ResponseTypes.Void>,
+    for endpoint: HelixEndpoint<
+      VoidResponse, VoidResponse, HelixEndpointResponseTypes.Void
+    >,
     completionHandler: @escaping @Sendable (HelixError?) -> Void
   ) {
     Task {
@@ -67,36 +54,8 @@ extension TwitchClient {
     }
   }
 
-  public func requestTask<R: Decodable>(
-    for endpoint: HelixEndpoint<ResponseTypes.Array<R>>,
-    completionHandler: @escaping @Sendable (HelixResponse<R>?, HelixError?) -> Void
-  ) {
-    Task {
-      do {
-        let result = try await self.request(endpoint: endpoint)
-        completionHandler(result, nil)
-      } catch let error as HelixError {
-        completionHandler(nil, error)
-      }
-    }
-  }
-
-  public func requestTask<R: Decodable>(
-    for endpoint: HelixEndpoint<ResponseTypes.Object<R>>,
-    completionHandler: @escaping @Sendable (R?, HelixError?) -> Void
-  ) {
-    Task {
-      do {
-        let result = try await self.request(endpoint: endpoint)
-        completionHandler(result, nil)
-      } catch let error as HelixError {
-        completionHandler(nil, error)
-      }
-    }
-  }
-
-  public func requestTask<R: Decodable>(
-    for endpoint: HelixEndpoint<ResponseTypes.Optional<R>>,
+  public func requestTask<R: Decodable, H: Decodable>(
+    for endpoint: HelixEndpoint<R, H, HelixEndpointResponseTypes.Normal>,
     completionHandler: @escaping @Sendable (R?, HelixError?) -> Void
   ) {
     Task {
@@ -114,7 +73,9 @@ extension TwitchClient {
   #if canImport(Combine)
 
     public func requestPublisher(
-      for endpoint: HelixEndpoint<ResponseTypes.Void>
+      for endpoint: HelixEndpoint<
+        VoidResponse, VoidResponse, HelixEndpointResponseTypes.Void
+      >
     ) -> AnyPublisher<Void, HelixError> {
       return Future { promise in
         Task {
@@ -128,39 +89,9 @@ extension TwitchClient {
       }.eraseToAnyPublisher()
     }
 
-    public func requestPublisher<R>(
-      for endpoint: HelixEndpoint<ResponseTypes.Array<R>>
-    ) -> AnyPublisher<HelixResponse<R>, HelixError> {
-      return Future { promise in
-        Task {
-          do {
-            let result = try await self.request(endpoint: endpoint)
-            promise(.success(result))
-          } catch let error as HelixError {
-            promise(.failure(error))
-          }
-        }
-      }.eraseToAnyPublisher()
-    }
-
-    public func requestPublisher<R>(
-      for endpoint: HelixEndpoint<ResponseTypes.Object<R>>
+    public func requestPublisher<R: Decodable, H: Decodable>(
+      for endpoint: HelixEndpoint<R, H, HelixEndpointResponseTypes.Normal>
     ) -> AnyPublisher<R, HelixError> {
-      return Future { promise in
-        Task {
-          do {
-            let result = try await self.request(endpoint: endpoint)
-            promise(.success(result))
-          } catch let error as HelixError {
-            promise(.failure(error))
-          }
-        }
-      }.eraseToAnyPublisher()
-    }
-
-    public func requestPublisher<R>(
-      for endpoint: HelixEndpoint<ResponseTypes.Optional<R>>
-    ) -> AnyPublisher<R?, HelixError> {
       return Future { promise in
         Task {
           do {
@@ -177,7 +108,11 @@ extension TwitchClient {
 
   // MARK: - Networking implementation
 
-  private func data(for endpoint: HelixEndpoint<some ResponseType>)
+  private func data(
+    for endpoint: HelixEndpoint<
+      some Decodable, some Decodable, some HelixEndpointResponseType
+    >
+  )
     async throws -> Data
   {
     let request = endpoint.makeRequest(using: self.authentication)

--- a/Sources/Twitch/Helix/TwitchClient+Helix.swift
+++ b/Sources/Twitch/Helix/TwitchClient+Helix.swift
@@ -12,7 +12,7 @@ extension TwitchClient {
   // MARK: - Async methods
 
   public func request(
-    endpoint: HelixEndpoint<some Any, some Any, HelixEndpointResponseTypes.Void>
+    endpoint: HelixEndpoint<EmptyResponse, EmptyResponse, HelixEndpointResponseTypes.Void>
   ) async throws {
     let data = try await self.data(for: endpoint)
 
@@ -34,7 +34,9 @@ extension TwitchClient {
   // MARK: - Callback methods
 
   public func requestTask(
-    for endpoint: HelixEndpoint<some Any, some Any, HelixEndpointResponseTypes.Void>,
+    for endpoint: HelixEndpoint<
+      EmptyResponse, EmptyResponse, HelixEndpointResponseTypes.Void
+    >,
     completionHandler: @escaping @Sendable (HelixError?) -> Void
   ) {
     Task {
@@ -66,7 +68,9 @@ extension TwitchClient {
   #if canImport(Combine)
 
     public func requestPublisher(
-      for endpoint: HelixEndpoint<some Any, some Any, HelixEndpointResponseTypes.Void>
+      for endpoint: HelixEndpoint<
+        EmptyResponse, EmptyResponse, HelixEndpointResponseTypes.Void
+      >
     ) -> AnyPublisher<Void, HelixError> {
       return Future { promise in
         Task {

--- a/Sources/Twitch/Helix/TwitchClient+Helix.swift
+++ b/Sources/Twitch/Helix/TwitchClient+Helix.swift
@@ -13,9 +13,7 @@ extension TwitchClient {
 
   public func request(
     endpoint: HelixEndpoint<some Any, some Any, HelixEndpointResponseTypes.Void>
-  )
-    async throws
-  {
+  ) async throws {
     let data = try await self.data(for: endpoint)
 
     guard data.isEmpty else {
@@ -26,10 +24,7 @@ extension TwitchClient {
 
   public func request<R, H: Decodable>(
     endpoint: HelixEndpoint<R, H, HelixEndpointResponseTypes.Normal>
-  )
-    async throws
-    -> R
-  {
+  ) async throws -> R {
     let data = try await self.data(for: endpoint)
     let response = try self.decode(data) as HelixResponse<H>
 

--- a/Tests/TwitchTests/API/Endpoints/AdsTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/AdsTests.swift
@@ -30,8 +30,7 @@ final class AdsTests: XCTestCase {
       data: [.get: MockedData.getAdScheduleJSON]
     ).register()
 
-    let ads = try await twitch.request(endpoint: .getAdSchedule(of: "1234"))
-      .data
+    let ads = try await twitch.request(endpoint: .getAdSchedule())
 
     XCTAssertEqual(ads.count, 1)
 
@@ -48,7 +47,7 @@ final class AdsTests: XCTestCase {
     ).register()
 
     let commercial = try await twitch.request(
-      endpoint: .startCommercial(on: "1234", length: 60)
+      endpoint: .startCommercial(length: 60)
     )
 
     XCTAssertEqual(commercial.length, 60)
@@ -66,13 +65,10 @@ final class AdsTests: XCTestCase {
       data: [.post: MockedData.snoozeNextAdJSON]
     ).register()
 
-    let snoozeResult = try await twitch.request(
-      endpoint: .snoozeNextAd(on: "1234")
-    ).data
+    let snoozeResult = try await twitch.request(endpoint: .snoozeNextAd())
 
-    XCTAssertEqual(snoozeResult.count, 1)
-    XCTAssertEqual(snoozeResult.first?.snoozeCount, 1)
+    XCTAssertEqual(snoozeResult.snoozeCount, 1)
     XCTAssertEqual(
-      snoozeResult.first?.snoozeRefreshAt.formatted(.iso8601), "2023-08-01T23:08:18Z")
+      snoozeResult.snoozeRefreshAt.formatted(.iso8601), "2023-08-01T23:08:18Z")
   }
 }

--- a/Tests/TwitchTests/API/Endpoints/AnalyticsTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/AnalyticsTests.swift
@@ -30,7 +30,7 @@ final class AnalyticsTests: XCTestCase {
       data: [.get: MockedData.getExtensionAnalyticsJSON]
     ).register()
 
-    let analytics = try await twitch.request(endpoint: .getExtensionAnalytics()).data
+    let (analytics, _) = try await twitch.request(endpoint: .getExtensionAnalytics())
 
     XCTAssertEqual(analytics.count, 1)
     XCTAssert(analytics.contains(where: { $0.extensionID == "efgh" }))
@@ -48,7 +48,7 @@ final class AnalyticsTests: XCTestCase {
       data: [.get: MockedData.getGameAnalyticsJSON]
     ).register()
 
-    let analytics = try await twitch.request(endpoint: .getGameAnalytics()).data
+    let (analytics, _) = try await twitch.request(endpoint: .getGameAnalytics())
 
     XCTAssertEqual(analytics.count, 1)
 

--- a/Tests/TwitchTests/API/Endpoints/ChannelsTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/ChannelsTests.swift
@@ -34,7 +34,6 @@ final class ChannelsTests: XCTestCase {
     let channels = try await twitch.request(
       endpoint: .getChannels(["141981764"])
     )
-    .data
 
     XCTAssertEqual(channels.count, 1)
     XCTAssert(channels.contains(where: { $0.id == "141981764" }))
@@ -49,9 +48,7 @@ final class ChannelsTests: XCTestCase {
       data: [.get: MockedData.getChannelEditorsJSON]
     ).register()
 
-    let editors = try await twitch.request(
-      endpoint: .getChannelEditors(of: "1234")
-    ).data
+    let editors = try await twitch.request(endpoint: .getChannelEditors())
 
     XCTAssertEqual(editors.count, 2)
 
@@ -69,23 +66,21 @@ final class ChannelsTests: XCTestCase {
       data: [.get: MockedData.getFollowedChannelsJSON]
     ).register()
 
-    let result = try await twitch.request(
-      endpoint: .getFollowedChannels(of: "1234")
-    )
+    let result = try await twitch.request(endpoint: .getFollowedChannels())
 
     XCTAssertEqual(result.total, 8)
 
-    XCTAssertEqual(result.data.first?.broadcasterID, "11111")
+    XCTAssertEqual(result.follows.first?.broadcasterID, "11111")
     XCTAssertEqual(
-      result.data.first?.followedAt.formatted(.iso8601), "2022-05-24T22:22:08Z")
+      result.follows.first?.followedAt.formatted(.iso8601), "2022-05-24T22:22:08Z")
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6NX19")
+    XCTAssertEqual(result.cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6NX19")
   }
 
   func testCheckFollow() async throws {
     let url = URL(
       string:
-        "https://api.twitch.tv/helix/channels/followed?user_id=123456&broadcaster_id=654321"
+        "https://api.twitch.tv/helix/channels/followed?user_id=1234&broadcaster_id=654321"
     )!
 
     Mock(
@@ -94,7 +89,7 @@ final class ChannelsTests: XCTestCase {
     ).register()
 
     let follow = try await twitch.request(
-      endpoint: .checkFollow(from: "123456", to: "654321")
+      endpoint: .checkFollow(to: "654321")
     )
 
     XCTAssertEqual(follow?.broadcasterID, "654321")
@@ -111,16 +106,16 @@ final class ChannelsTests: XCTestCase {
     ).register()
 
     let result = try await twitch.request(
-      endpoint: .getFollowers(of: "1234")
+      endpoint: .getChannelFollowers(of: "1234")
     )
 
     XCTAssertEqual(result.total, 8)
 
-    XCTAssertEqual(result.data.first?.userID, "11111")
+    XCTAssertEqual(result.followers.first?.userID, "11111")
     XCTAssertEqual(
-      result.data.first?.followedAt.formatted(.iso8601), "2022-05-24T22:22:08Z")
+      result.followers.first?.followedAt.formatted(.iso8601), "2022-05-24T22:22:08Z")
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6NX19")
+    XCTAssertEqual(result.cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6NX19")
   }
 
   func testCheckChannelFollower() async throws {
@@ -151,8 +146,7 @@ final class ChannelsTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .updateChannel("1234", gameID: "1234"))
+    try await twitch.request(endpoint: .updateChannel(gameID: "1234"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }

--- a/Tests/TwitchTests/API/Endpoints/ChatTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/ChatTests.swift
@@ -32,15 +32,14 @@ final class ChatTests: XCTestCase {
       data: [.get: MockedData.getChattersJSON]
     ).register()
 
-    let result = try await twitch.request(
-      endpoint: .getChatters(in: "123", moderatorID: "1234"))
+    let result = try await twitch.request(endpoint: .getChatters(in: "123"))
 
-    XCTAssertEqual(result.data.count, 1)
+    XCTAssertEqual(result.chatters.count, 1)
     XCTAssertEqual(result.total, 8)
     XCTAssertEqual(
-      result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6NX19")
+      result.cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6NX19")
 
-    XCTAssert(result.data.contains(where: { $0.userID == "128393656" }))
+    XCTAssert(result.chatters.contains(where: { $0.userID == "128393656" }))
   }
 
   func testGetChannelEmotes() async throws {
@@ -59,12 +58,12 @@ final class ChatTests: XCTestCase {
       "https://static-cdn.jtvnw.net/emoticons/v2/{{id}}/{{format}}/{{theme_mode}}/{{scale}}"
     )
 
-    XCTAssertEqual(result.data.count, 2)
-    XCTAssert(result.data.contains(where: { $0.id == "304456832" }))
+    XCTAssertEqual(result.emotes.count, 2)
+    XCTAssert(result.emotes.contains(where: { $0.id == "304456832" }))
 
-    let emote = result.data.first(where: { $0.id == "304456832" })
+    let emote = result.emotes.first(where: { $0.id == "304456832" })
     XCTAssertEqual(
-      emote?.getURL(from: result.template!)?.absoluteString,
+      emote?.getURL(from: result.template)?.absoluteString,
       "https://static-cdn.jtvnw.net/emoticons/v2/304456832/static/dark/3.0")
   }
 
@@ -83,12 +82,12 @@ final class ChatTests: XCTestCase {
       "https://static-cdn.jtvnw.net/emoticons/v2/{{id}}/{{format}}/{{theme_mode}}/{{scale}}"
     )
 
-    XCTAssertEqual(result.data.count, 1)
-    XCTAssert(result.data.contains(where: { $0.id == "196892" }))
+    XCTAssertEqual(result.emotes.count, 1)
+    XCTAssert(result.emotes.contains(where: { $0.id == "196892" }))
 
-    let emote = result.data.first(where: { $0.id == "196892" })
+    let emote = result.emotes.first(where: { $0.id == "196892" })
     XCTAssertEqual(
-      emote?.getURL(from: result.template!)?.absoluteString,
+      emote?.getURL(from: result.template)?.absoluteString,
       "https://static-cdn.jtvnw.net/emoticons/v2/196892/static/dark/3.0")
   }
 
@@ -110,12 +109,12 @@ final class ChatTests: XCTestCase {
       "https://static-cdn.jtvnw.net/emoticons/v2/{{id}}/{{format}}/{{theme_mode}}/{{scale}}"
     )
 
-    XCTAssertEqual(result.data.count, 1)
-    XCTAssert(result.data.contains(where: { $0.id == "304456832" }))
+    XCTAssertEqual(result.emotes.count, 1)
+    XCTAssert(result.emotes.contains(where: { $0.id == "304456832" }))
 
-    let emote = result.data.first(where: { $0.id == "304456832" })
+    let emote = result.emotes.first(where: { $0.id == "304456832" })
     XCTAssertEqual(
-      emote?.getURL(from: result.template!)?.absoluteString,
+      emote?.getURL(from: result.template)?.absoluteString,
       "https://static-cdn.jtvnw.net/emoticons/v2/304456832/static/dark/3.0")
   }
 
@@ -129,7 +128,7 @@ final class ChatTests: XCTestCase {
 
     let badgeSets = try await twitch.request(
       endpoint: .getChannelBadges(of: "1234")
-    ).data
+    )
 
     XCTAssertEqual(badgeSets.count, 2)
 
@@ -146,7 +145,7 @@ final class ChatTests: XCTestCase {
       data: [.get: MockedData.getGlobalBadgesJSON]
     ).register()
 
-    let badgeSets = try await twitch.request(endpoint: .getGlobalBadges()).data
+    let badgeSets = try await twitch.request(endpoint: .getGlobalBadges())
 
     XCTAssertEqual(badgeSets.count, 1)
 
@@ -191,8 +190,7 @@ final class ChatTests: XCTestCase {
 
     let settings = try await twitch.request(
       endpoint: .updateChatSettings(
-        of: "713936733", moderatorID: "1234", .slowMode(5), .subscriberMode,
-        .followerMode()))
+        of: "713936733", .slowMode(5), .subscriberMode, .followerMode()))
 
     XCTAssertEqual(settings.broadcasterID, "713936733")
     XCTAssertEqual(settings.slowModeWaitTime, 5)
@@ -217,9 +215,7 @@ final class ChatTests: XCTestCase {
     mock.register()
 
     try await twitch.request(
-      endpoint: .sendAnnouncement(
-        in: "1234", message: "Hello, world!", color: .blue, moderatorID: "1234"
-      ))
+      endpoint: .sendAnnouncement(in: "1234", message: "Hello, world!", color: .blue))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -237,8 +233,7 @@ final class ChatTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .sendShoutout(from: "1234", to: "4321", moderatorID: "1234"))
+    try await twitch.request(endpoint: .sendShoutout(from: "1234", to: "4321"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -254,7 +249,7 @@ final class ChatTests: XCTestCase {
 
     let colors = try await twitch.request(
       endpoint: .getUserColors(of: ["11111", "44444"])
-    ).data
+    )
 
     XCTAssertEqual(colors.count, 2)
 
@@ -272,8 +267,7 @@ final class ChatTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .updateUserColor(of: "1234", color: .blue))
+    try await twitch.request(endpoint: .updateUserColor(to: .blue))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }

--- a/Tests/TwitchTests/API/Endpoints/ContentClassificationLabelsTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/ContentClassificationLabelsTests.swift
@@ -32,7 +32,6 @@ final class ContentClassificationLabelsTests: XCTestCase {
     ).register()
 
     let labels = try await twitch.request(endpoint: .getContentClassificationLabels())
-      .data
 
     XCTAssertEqual(labels.count, 6)
     XCTAssert(labels.contains(where: { $0.id == "ViolentGraphic" }))

--- a/Tests/TwitchTests/API/Endpoints/GamesTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/GamesTests.swift
@@ -29,7 +29,7 @@ final class GamesTests: XCTestCase {
       url: url, contentType: .json, statusCode: 200, data: [.get: MockedData.getGamesJSON]
     ).register()
 
-    let games = try await twitch.request(endpoint: .getGames(gameIDs: ["33214"])).data
+    let games = try await twitch.request(endpoint: .getGames(gameIDs: ["33214"]))
 
     XCTAssertEqual(games.count, 1)
     XCTAssert(games.contains(where: { $0.id == "33214" }))
@@ -43,11 +43,11 @@ final class GamesTests: XCTestCase {
       data: [.get: MockedData.getTopGamesJSON]
     ).register()
 
-    let result = try await twitch.request(endpoint: .getTopGames(limit: 1))
+    let (games, cursor) = try await twitch.request(endpoint: .getTopGames(limit: 1))
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6MjB9fQ==")
+    XCTAssertEqual(cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6MjB9fQ==")
 
-    XCTAssertEqual(result.data.count, 1)
-    XCTAssert(result.data.contains(where: { $0.id == "493057" }))
+    XCTAssertEqual(games.count, 1)
+    XCTAssert(games.contains(where: { $0.id == "493057" }))
   }
 }

--- a/Tests/TwitchTests/API/Endpoints/ModerationTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/ModerationTests.swift
@@ -36,10 +36,9 @@ final class ModerationTests: XCTestCase {
 
     let result = try await twitch.request(
       endpoint: .checkAutomodStatus(
-        in: "1234",
         messages: ("123", "This is a test message."),
         ("393", "This is another test message."))
-    ).data
+    )
 
     XCTAssertEqual(result.count, 2)
     XCTAssertEqual(result[0].messageID, "123")
@@ -58,8 +57,7 @@ final class ModerationTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .approveAutomodMessage(messageID: "123", moderatorID: "1234"))
+    try await twitch.request(endpoint: .approveAutomodMessage(messageID: "123"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -74,8 +72,7 @@ final class ModerationTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .denyAutomodMessage(messageID: "123", moderatorID: "1234"))
+    try await twitch.request(endpoint: .denyAutomodMessage(messageID: "123"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -91,8 +88,7 @@ final class ModerationTests: XCTestCase {
       data: [.get: MockedData.getAutomodSettingsJSON]
     ).register()
 
-    let result = try await twitch.request(
-      endpoint: .getAutomodSettings(of: "5678", moderatorID: "1234"))
+    let result = try await twitch.request(endpoint: .getAutomodSettings(of: "5678"))
 
     XCTAssertEqual(result.broadcasterID, "5678")
     XCTAssertEqual(result.moderatorID, "1234")
@@ -113,8 +109,7 @@ final class ModerationTests: XCTestCase {
     ).register()
 
     let result = try await twitch.request(
-      endpoint: .updateAutomodSettings(
-        of: "5678", overall: 3, moderatorID: "1234"))
+      endpoint: .updateAutomodSettings(of: "5678", overall: 3))
 
     XCTAssertEqual(result.broadcasterID, "5678")
     XCTAssertEqual(result.moderatorID, "1234")
@@ -139,12 +134,12 @@ final class ModerationTests: XCTestCase {
       data: [.get: MockedData.getBannedUsersJSON]
     ).register()
 
-    let result = try await twitch.request(endpoint: .getBannedUsers(in: "1234"))
+    let (bans, cursor) = try await twitch.request(endpoint: .getBannedUsers())
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI")
+    XCTAssertEqual(cursor, "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI")
 
-    XCTAssertEqual(result.data.count, 2)
-    XCTAssertEqual(result.data.first?.userID, "423374343")
+    XCTAssertEqual(bans.count, 2)
+    XCTAssertEqual(bans.first?.userID, "423374343")
   }
 
   func testBanUser() async throws {
@@ -157,8 +152,7 @@ final class ModerationTests: XCTestCase {
       url: url, contentType: .json, statusCode: 200, data: [.post: MockedData.banUserJSON]
     ).register()
 
-    let ban = try await twitch.request(
-      endpoint: .banUser("9876", in: "5678", moderatorID: "1234"))
+    let ban = try await twitch.request(endpoint: .banUser("9876", in: "5678"))
 
     XCTAssertEqual(ban.broadcasterID, "5678")
     XCTAssertEqual(ban.moderatorID, "1234")
@@ -179,8 +173,7 @@ final class ModerationTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .unbanUser("9876", in: "5678", moderatorID: "1234"))
+    try await twitch.request(endpoint: .unbanUser("9876", in: "5678"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -196,12 +189,10 @@ final class ModerationTests: XCTestCase {
       data: [.get: MockedData.getBlockedTermsJSON]
     ).register()
 
-    let result = try await twitch.request(
-      endpoint: .getBlockedTerms(
-        in: "5678", moderatorID: "1234"))
-    let terms = result.data
+    let (terms, cursor) = try await twitch.request(
+      endpoint: .getBlockedTerms(in: "5678"))
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6I")
+    XCTAssertEqual(cursor, "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6I")
 
     XCTAssertEqual(terms.count, 1)
     XCTAssertEqual(terms.first?.text, "A phrase I'm not fond of")
@@ -220,8 +211,7 @@ final class ModerationTests: XCTestCase {
     ).register()
 
     let term = try await twitch.request(
-      endpoint: .addBlockedTerm(
-        in: "5678", text: "A phrase I'm not fond of", moderatorID: "1234"))
+      endpoint: .addBlockedTerm(in: "5678", text: "A phrase I'm not fond of"))
 
     XCTAssertEqual(term.broadcasterID, "5678")
     XCTAssertEqual(term.moderatorID, "1234")
@@ -243,8 +233,7 @@ final class ModerationTests: XCTestCase {
     mock.register()
 
     try await twitch.request(
-      endpoint: .removeBlockedTerm(
-        in: "5678", termID: "9876", moderatorID: "1234"))
+      endpoint: .removeBlockedTerm(in: "5678", termID: "9876"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -262,9 +251,7 @@ final class ModerationTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .deleteChatMessage(
-        in: "5678", messageID: "9876", moderatorID: "1234"))
+    try await twitch.request(endpoint: .deleteChatMessage(in: "5678", messageID: "9876"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -277,10 +264,9 @@ final class ModerationTests: XCTestCase {
       data: [.get: MockedData.getModeratedChannelsJSON]
     ).register()
 
-    let result = try await twitch.request(endpoint: .getModeratedChannels(of: "1234"))
-    let channels = result.data
+    let (channels, cursor) = try await twitch.request(endpoint: .getModeratedChannels())
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6")
+    XCTAssertEqual(cursor, "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6")
 
     XCTAssertEqual(channels.count, 2)
     XCTAssertEqual(channels.first?.id, "12345")
@@ -296,12 +282,12 @@ final class ModerationTests: XCTestCase {
       data: [.get: MockedData.getModeratorsJSON]
     ).register()
 
-    let result = try await twitch.request(endpoint: .getModerators(of: "1234"))
+    let (mods, cursor) = try await twitch.request(endpoint: .getModerators())
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6I")
+    XCTAssertEqual(cursor, "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6I")
 
-    XCTAssertEqual(result.data.count, 1)
-    XCTAssertEqual(result.data.first?.id, "424596340")
+    XCTAssertEqual(mods.count, 1)
+    XCTAssertEqual(mods.first?.id, "424596340")
   }
 
   func testAddChannelModerator() async throws {
@@ -317,8 +303,7 @@ final class ModerationTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .addChannelModerator(in: "1234", userID: "9876"))
+    try await twitch.request(endpoint: .addChannelModerator(userID: "9876"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -336,8 +321,7 @@ final class ModerationTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .removeChannelModerator(in: "1234", userID: "9876"))
+    try await twitch.request(endpoint: .removeChannelModerator(userID: "9876"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -350,12 +334,12 @@ final class ModerationTests: XCTestCase {
       url: url, contentType: .json, statusCode: 200, data: [.get: MockedData.getVIPsJSON]
     ).register()
 
-    let result = try await twitch.request(endpoint: .getVIPs(of: "1234"))
+    let (vips, cursor) = try await twitch.request(endpoint: .getVIPs())
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6NX19")
+    XCTAssertEqual(cursor, "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6NX19")
 
-    XCTAssertEqual(result.data.count, 1)
-    XCTAssertEqual(result.data.first?.id, "11111")
+    XCTAssertEqual(vips.count, 1)
+    XCTAssertEqual(vips.first?.id, "11111")
   }
 
   func testAddChannelVIP() async throws {
@@ -370,7 +354,7 @@ final class ModerationTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(endpoint: .addChannelVIP(in: "1234", userID: "9876"))
+    try await twitch.request(endpoint: .addChannelVIP(userID: "9876"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -387,7 +371,7 @@ final class ModerationTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(endpoint: .removeChannelVIP(in: "1234", userID: "9876"))
+    try await twitch.request(endpoint: .removeChannelVIP(userID: "9876"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }
@@ -403,8 +387,7 @@ final class ModerationTests: XCTestCase {
       data: [.get: MockedData.getShieldModeStatusJSON]
     ).register()
 
-    let result = try await twitch.request(
-      endpoint: .getShieldModeStatus(of: "5678", moderatorID: "1234"))
+    let result = try await twitch.request(endpoint: .getShieldModeStatus(of: "5678"))
 
     XCTAssertEqual(result.isActive, true)
     XCTAssertEqual(result.moderatorID, "1234")
@@ -422,8 +405,7 @@ final class ModerationTests: XCTestCase {
     ).register()
 
     let result = try await twitch.request(
-      endpoint: .updateShieldModeStatus(
-        of: "5678", isActive: true, moderatorID: "1234"))
+      endpoint: .updateShieldModeStatus(of: "5678", isActive: true))
 
     XCTAssertEqual(result.isActive, true)
     XCTAssertEqual(result.moderatorID, "1234")

--- a/Tests/TwitchTests/API/Endpoints/SearchTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/SearchTests.swift
@@ -30,12 +30,13 @@ final class SearchTests: XCTestCase {
       data: [.get: MockedData.searchCategoriesJSON]
     ).register()
 
-    let result = try await twitch.request(endpoint: .searchCategories(for: "fort"))
+    let (categories, cursor) = try await twitch.request(
+      endpoint: .searchCategories(for: "fort"))
 
-    XCTAssertEqual(result.pagination?.cursor, "eyJiIjpudWxsLCJhIjp7IkN")
+    XCTAssertEqual(cursor, "eyJiIjpudWxsLCJhIjp7IkN")
 
-    XCTAssertEqual(result.data.count, 1)
-    XCTAssert(result.data.contains(where: { $0.id == "33214" }))
+    XCTAssertEqual(categories.count, 1)
+    XCTAssert(categories.contains(where: { $0.id == "33214" }))
   }
 
   func testSearchChannels() async throws {
@@ -46,11 +47,12 @@ final class SearchTests: XCTestCase {
       data: [.get: MockedData.searchChannelsJSON]
     ).register()
 
-    let result = try await twitch.request(endpoint: .searchChannels(for: "loser"))
+    let (channels, cursor) = try await twitch.request(
+      endpoint: .searchChannels(for: "loser"))
 
-    XCTAssertNil(result.pagination?.cursor)
+    XCTAssertNil(cursor)
 
-    XCTAssertEqual(result.data.count, 2)
-    XCTAssert(result.data.contains(where: { $0.id == "41245072" }))
+    XCTAssertEqual(channels.count, 2)
+    XCTAssert(channels.contains(where: { $0.id == "41245072" }))
   }
 }

--- a/Tests/TwitchTests/API/Endpoints/StreamsTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/StreamsTests.swift
@@ -30,12 +30,12 @@ final class StreamsTests: XCTestCase {
       data: [.get: MockedData.getStreamsJSON]
     ).register()
 
-    let result = try await twitch.request(endpoint: .getStreams(limit: 1))
+    let (streams, cursor) = try await twitch.request(endpoint: .getStreams(limit: 1))
 
-    XCTAssertNil(result.pagination?.cursor)
+    XCTAssertNil(cursor)
 
-    XCTAssertEqual(result.data.count, 1)
-    XCTAssert(result.data.contains(where: { $0.id == "40952121085" }))
+    XCTAssertEqual(streams.count, 1)
+    XCTAssert(streams.contains(where: { $0.id == "40952121085" }))
   }
 
   func testGetFollowedStreams() async throws {
@@ -47,10 +47,8 @@ final class StreamsTests: XCTestCase {
       data: [.get: MockedData.getFollowedStreamsJSON]
     ).register()
 
-    let result = try await twitch.request(
-      endpoint: .getFollowedStreams(of: "1234", limit: 1))
-    let streams = result.data
-    let cursor = result.pagination?.cursor
+    let (streams, cursor) = try await twitch.request(
+      endpoint: .getFollowedStreams(limit: 1))
 
     XCTAssertEqual(cursor, "eyJiIjp7IkN1cnNvciI6ImV5SnpJam8zT0RNMk5TNDBORFF4")
 

--- a/Tests/TwitchTests/API/Endpoints/SubscriptionsTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/SubscriptionsTests.swift
@@ -32,13 +32,13 @@ final class SubscriptionsTests: XCTestCase {
     ).register()
 
     let result = try await twitch.request(
-      endpoint: .getSubscribers(of: "1234", limit: 2))
-    let subscribers = result.data
+      endpoint: .getSubscribers(limit: 2))
+    let subscribers = result.subscribers
 
     XCTAssertEqual(result.total, 13)
     XCTAssertEqual(result.points, 13)
 
-    XCTAssertEqual(result.pagination?.cursor, "jnksdfyg7is8do7fv7yuwbisudg")
+    XCTAssertEqual(result.cursor, "jnksdfyg7is8do7fv7yuwbisudg")
 
     XCTAssertEqual(subscribers.count, 2)
     XCTAssertNotNil(subscribers.first?.gifter)
@@ -58,8 +58,7 @@ final class SubscriptionsTests: XCTestCase {
       data: [.get: MockedData.checkUserSubscriptionJSON]
     ).register()
 
-    let subscription = try await twitch.request(
-      endpoint: .checkSubscription(of: "1234", to: "1234"))
+    let subscription = try await twitch.request(endpoint: .checkSubscription(to: "1234"))
 
     XCTAssertEqual(subscription?.broadcasterID, "141981764")
     XCTAssertEqual(subscription?.gifter?.id, "12826")

--- a/Tests/TwitchTests/API/Endpoints/UsersTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/UsersTests.swift
@@ -29,7 +29,7 @@ final class UsersTests: XCTestCase {
       url: url, contentType: .json, statusCode: 200, data: [.get: MockedData.getUsersJSON]
     ).register()
 
-    let users = try await twitch.request(endpoint: .getUsers(ids: ["141981764"])).data
+    let users = try await twitch.request(endpoint: .getUsers(ids: ["141981764"]))
 
     XCTAssertEqual(users.count, 1)
 
@@ -62,9 +62,7 @@ final class UsersTests: XCTestCase {
       data: [.get: MockedData.getUserBlocklistJSON]
     ).register()
 
-    let blocks = try await twitch.request(
-      endpoint: .getBlocklist(of: "1234", limit: 2)
-    ).data
+    let blocks = try await twitch.request(endpoint: .getBlocklist(limit: 2))
 
     XCTAssertEqual(blocks.count, 2)
     XCTAssert(blocks.contains(where: { $0.userID == "135093069" }))

--- a/Tests/TwitchTests/API/Endpoints/WhispersTests.swift
+++ b/Tests/TwitchTests/API/Endpoints/WhispersTests.swift
@@ -33,8 +33,7 @@ final class WhispersTests: XCTestCase {
     let completionExpectation = expectationForCompletingMock(&mock)
     mock.register()
 
-    try await twitch.request(
-      endpoint: .sendWhisper(from: "1234", to: "4321", message: "Hello, world!"))
+    try await twitch.request(endpoint: .sendWhisper(to: "4321", message: "Hello, world!"))
 
     await fulfillment(of: [completionExpectation], timeout: 2.0)
   }

--- a/Tests/TwitchTests/API/MockedEndpoints.swift
+++ b/Tests/TwitchTests/API/MockedEndpoints.swift
@@ -2,11 +2,22 @@ import Foundation
 
 @testable import Twitch
 
-extension HelixEndpoint where Response == ResponseTypes.Object<String> {
+extension HelixEndpoint
+where
+  EndpointResponseType == HelixEndpointResponseTypes.Normal,
+  ResponseType == String?, HelixResponseType == String
+{
   public static func custom(
     method: String, path: String, queryItems: [URLQueryItem]? = nil,
     body: [String: String]? = nil
   ) -> Self {
-    return .init(method: method, path: path, queryItems: queryItems, body: body)
+    return .init(
+      method: method, path: path,
+      queryItems: { _ in
+        queryItems.map {
+          $0.map { ($0.name, $0.value) }
+        } ?? []
+      }, body: { _ in body },
+      makeResponse: { $0.data.first })
   }
 }


### PR DESCRIPTION
Rewrite the Helix generics once again, to enable another custom parsing step after the JSONDecoder is finished, meant to handle additional response data like pagination, total sub points, etc. and build a final response containing only the data relevant to that endpoint.