### PR TITLE
fix(IRC): handle expected websocket error when leaving last room

### DIFF
--- a/Sources/Twitch/IRC/IRCConnectionPool.swift
+++ b/Sources/Twitch/IRC/IRCConnectionPool.swift
@@ -83,8 +83,12 @@ public actor IRCConnectionPool {
     let messageStream = try await connection.connect()
 
     Task {
-      for try await message in messageStream {
-        self.continuation?.yield(message)
+      do {
+        for try await message in messageStream {
+          self.continuation?.yield(message)
+        }
+      } catch {
+        self.continuation?.finish(throwing: error)
       }
     }
 


### PR DESCRIPTION
Hiya! Bringing a quick one here for review.

I was noticing some unexpected states in my app and I was able to pin the issue down to some errors being thrown by `IRCConnection` that were not being handled upstream.  The specific error I was seeing happened because it turns out that when the `IRCConnection` 'parts' from the last room it was connected to, the websocket gets disconnected. This causes the next call to `websocket.receive()` to throw an error.

I have added some logic to handle this and also made sure to bubble up any unhandled errors so they don't get 'eaten' in the `Task` calls and they can be properly handled by the client. Let me know what you think!

Cheers.