### PR TITLE
fix: update CI dependencies to the newest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
             echo "Swift ${{ matrix.swift-version }} already installed, skipping installation."
           else
             if [[ "$RUNNER_OS" == "Linux" ]]; then
+              echo "Disabling man-db on Linux..."
+              sudo apt-get remove -y man-db || true
+              sudo apt-get update
+
               echo "Installing Swiftly on Linux..."
               curl -L https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz > swiftly.tar.gz
               tar zxf swiftly.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,9 +61,11 @@ jobs:
 
             echo "Installing Swift ${{ matrix.swift-version }}..."
             swiftly install ${{ matrix.swift-version }} --post-install-file=post-install.sh
+
             if [[ -f post-install.sh ]]; then
               echo "Running post-install.sh..."
-              cat post-install.sh
+
+              # alias apt-get to automatically run with sudo
               bash -c '
                 shopt -s expand_aliases
                 alias apt-get="sudo apt-get"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache Swift toolchains
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/swiftly/toolchains
+            ~/.swiftly/toolchains
+          key: swift-toolchain-${{ runner.os }}-${{ matrix.swift-version }}
+
+      - name: Cache Swift build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: build-${{ runner.os }}-${{ matrix.swift-version }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            build-${{ runner.os }}-${{ matrix.swift-version }}-
+
       - name: Install Swiftly & Swift ${{ matrix.swift-version }}
         run: |
           if swift --version 2>/dev/null | grep -q "${{ matrix.swift-version }}"; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,16 +14,38 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            swift-version: "6.2"
+            swift-version: "6.2-snapshot"
           - os: macos-15
-            swift-version: "6.2"
+            swift-version: "6.2-snapshot"
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install Swift ${{ matrix.swift-version }}
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: ${{ matrix.swift-version }}
+
+      - name: Install Swiftly & Swift ${{ matrix.swift-version }}
+        run: |
+          if swift --version 2>/dev/null | grep -q "${{ matrix.swift-version }}"; then
+            echo "Swift ${{ matrix.swift-version }} already installed, skipping installation."
+          else
+            if [[ "$RUNNER_OS" == "Linux" ]]; then
+              echo "Installing Swiftly on Linux..."
+              curl -L https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz > swiftly.tar.gz
+              tar zxf swiftly.tar.gz
+              ./swiftly init --verbose --assume-yes --skip-install
+              source "/home/runner/.local/share/swiftly/env.sh"
+            elif [[ "$RUNNER_OS" == "macOS" ]]; then
+              echo "Installing Swiftly on macOS..."
+              brew install swiftly
+              swiftly init --verbose --assume-yes --skip-install || true
+              source "$HOME/.swiftly/env.sh"
+            fi
+
+            echo "Installing Swift ${{ matrix.swift-version }}..."
+            swiftly install ${{ matrix.swift-version }} --post-install-file=post-install.sh
+            if [[ -f post-install.sh ]]; then
+              source post-install.sh
+            fi
+          fi
+
       - name: Build
         run: swift build -v
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,13 @@ jobs:
             echo "Installing Swift ${{ matrix.swift-version }}..."
             swiftly install ${{ matrix.swift-version }} --post-install-file=post-install.sh
             if [[ -f post-install.sh ]]; then
-              source post-install.sh
+              echo "Running post-install.sh..."
+              cat post-install.sh
+              bash -c '
+                shopt -s expand_aliases
+                alias apt-get="sudo apt-get"
+                source post-install.sh
+              '
             fi
           fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,16 +14,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            swift-version: "5.10"
-          - os: macos-14
-            swift-version: "5.10"
+            swift-version: "6.2"
+          - os: macos-15
+            swift-version: "6.2"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Swift ${{ matrix.swift-version }}
-        uses: slashmo/install-swift@v0.4.0
+        uses: swift-actions/setup-swift@v2
         with:
-          version: ${{ matrix.swift-version }}
+          swift-version: ${{ matrix.swift-version }}
       - name: Build
         run: swift build -v
       - name: Test
@@ -31,11 +31,10 @@ jobs:
 
   lint:
     name: Lint
-    
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1
         with:
@@ -43,11 +42,10 @@ jobs:
 
   format:
     name: Check formatting
-  
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install apple/swift-format
         run: brew install swift-format
       - name: Check formatting


### PR DESCRIPTION
- switches to use the recommended [setup-swift](https://github.com/marketplace/actions/setup-swift) action for installing the appropriate version of Swift for the build/test phase
- updates [actions/checkout](https://github.com/actions/checkout) to `v4`
- updates to Swift 6.2 and macOS 15