### PR TITLE
feat: implement general EventSub tests using Swift Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,5 +27,8 @@ let package = Package(
     ),
     .testTarget(
       name: "TwitchTests", dependencies: ["Twitch", "Mocker"],
-      resources: [.process("API/MockResources")]),
+      resources: [
+        .process("API/MockResources"),
+        .process("EventSub/MockResources"),
+      ]),
   ])

--- a/Sources/Twitch/EventSub/EventSubConnection.swift
+++ b/Sources/Twitch/EventSub/EventSubConnection.swift
@@ -8,29 +8,36 @@ internal actor EventSubConnection {
   private let eventSubURL: URL
 
   private let credentials: TwitchCredentials
-  private let urlSession: URLSession
+  private let network: NetworkSession
   private let decoder: JSONDecoder
 
   private var keepaliveTimer: KeepaliveTimer?
-  private var websocket: URLSessionWebSocketTask?
+  private var websocket: WebSocketTask?
   private var socketID: String?
 
-  private var onMessage: ((Result<EventSubNotification, EventSubConnectionError>) -> Void)
+  private var onMessage:
+    (@Sendable (Result<EventSubNotification, EventSubConnectionError>) async -> Void)
   private var welcomeContinuation: CheckedContinuation<EventSubWelcome, any Error>?
 
   private var receivedMessageIDs = [String]()
 
   deinit {
-    self.websocket?.cancel(with: .goingAway, reason: nil)
+    Task.detached { [websocket] in
+      await websocket?.cancel(with: .goingAway, reason: nil)
+    }
   }
 
   init(
-    credentials: TwitchCredentials, urlSession: URLSession, decoder: JSONDecoder,
+    credentials: TwitchCredentials,
+    network: NetworkSession,
+    decoder: JSONDecoder,
     eventSubURL: URL,
-    onMessage: @escaping (Result<EventSubNotification, EventSubConnectionError>) -> Void
+    onMessage:
+      @Sendable @escaping (Result<EventSubNotification, EventSubConnectionError>) async ->
+      Void
   ) {
     self.credentials = credentials
-    self.urlSession = urlSession
+    self.network = network
     self.decoder = decoder
 
     self.eventSubURL = eventSubURL
@@ -41,9 +48,9 @@ internal actor EventSubConnection {
   internal func resume() async throws -> String {
     if let socketID = self.socketID { return socketID }
 
-    self.websocket = urlSession.webSocketTask(with: eventSubURL)
-    self.websocket?.resume()
-    self.scheduleReceive()
+    self.websocket = await network.webSocketTask(with: eventSubURL)
+    await self.websocket?.resume()
+    await self.scheduleReceive()
 
     // Twitch sends keepalive messages in a specified time interval,
     // if we don't receive a message within that interval, we should
@@ -51,7 +58,7 @@ internal actor EventSubConnection {
     self.keepaliveTimer = KeepaliveTimer(duration: .seconds(10)) {
       @Sendable [weak self] in
 
-      Task { await self?.handleKeepaliveTimeout() }
+      await self?.handleKeepaliveTimeout()
     }
 
     // wait for the welcome message to be received
@@ -67,8 +74,8 @@ internal actor EventSubConnection {
     return welcomeMessage.sessionID
   }
 
-  private func scheduleReceive() {
-    self.websocket?.receive { @Sendable [weak self] result in
+  private func scheduleReceive() async {
+    await self.websocket?.receive { @Sendable [weak self] result in
       Task { await self?.receiveMessage(result) }
     }
   }
@@ -82,10 +89,9 @@ internal actor EventSubConnection {
       await self.keepaliveTimer?.reset()
 
       if let message = parseMessage(message) {
-
         // ignore duplicate messages
         if !receivedMessageIDs.contains(message.id) {
-          handleMessage(message)
+          await handleMessage(message)
           receivedMessageIDs.append(message.id)
 
           // only keep the last 100 message IDs
@@ -96,7 +102,7 @@ internal actor EventSubConnection {
       }
 
       // recursively receive the next message
-      self.scheduleReceive()
+      await self.scheduleReceive()
     case .failure(let error):
       let disconnectedError = EventSubConnectionError.disconnected(
         with: error, socketID: socketID ?? "")
@@ -107,7 +113,7 @@ internal actor EventSubConnection {
       }
 
       await self.keepaliveTimer?.cancel()
-      onMessage(.failure(disconnectedError))
+      await onMessage(.failure(disconnectedError))
     }
   }
 
@@ -123,27 +129,32 @@ internal actor EventSubConnection {
     }
   }
 
-  private func handleMessage(_ message: EventSubMessage) {
+  private func handleMessage(_ message: EventSubMessage) async {
     switch message.payload {
     case .keepalive: break  // nothing to do for keepalive messages
     case .welcome(let welcome):
       welcomeContinuation?.resume(returning: welcome)
       welcomeContinuation = nil
     case .notification(let notification):
-      onMessage(.success(notification))
+      await onMessage(.success(notification))
     case .revocation(let revocation):
-      onMessage(.failure(EventSubConnectionError.revocation(revocation)))
+      await onMessage(.failure(EventSubConnectionError.revocation(revocation)))
     case .reconnect(let reconnect):
-      onMessage(
+      await onMessage(
         .failure(
           EventSubConnectionError.reconnectRequested(
             reconnectURL: reconnect.reconnectURL, socketID: socketID ?? "")))
     }
   }
 
-  private func handleKeepaliveTimeout() {
-    self.onMessage(
+  private func handleKeepaliveTimeout() async {
+    // NOTE: onMessage needs to be async because of this call, since the keepalive timer
+    // runs in a different thread, this call would otherwise cross actor boundaries. Swift
+    // Strict Concurrency checking cannot verify this at the moment, because the actor
+    // isolation gets erased in `EventSubClient` when passing an instance method as the
+    // handler to the connection.
+    await self.onMessage(
       .failure(EventSubConnectionError.timedOut(socketID: self.socketID ?? "")))
-    self.websocket?.cancel()
+    await self.websocket?.cancel(with: .goingAway, reason: nil)
   }
 }

--- a/Sources/Twitch/EventSub/EventSubConnection.swift
+++ b/Sources/Twitch/EventSub/EventSubConnection.swift
@@ -21,10 +21,9 @@ internal actor EventSubConnection {
 
   private var receivedMessageIDs = [String]()
 
-  deinit {
-    Task.detached { [websocket] in
-      await websocket?.cancel(with: .goingAway, reason: nil)
-    }
+  internal func cancel() async {
+    await websocket?.cancel(with: .goingAway, reason: nil)
+    await keepaliveTimer?.cancel()
   }
 
   init(

--- a/Sources/Twitch/EventSub/Events/Event.swift
+++ b/Sources/Twitch/EventSub/Events/Event.swift
@@ -12,6 +12,8 @@ internal enum EventType: String, Decodable {
     case .chatMessage: return ChatMessageEvent.self
     case .channelUpdate: return ChannelUpdateEvent.self
     case .chatClear: return ChatClearEvent.self
+
+    case .mock: return MockEvent.self
     }
   }
 }

--- a/Sources/Twitch/EventSub/Events/Event.swift
+++ b/Sources/Twitch/EventSub/Events/Event.swift
@@ -6,6 +6,8 @@ internal enum EventType: String, Decodable {
   case channelUpdate = "channel.update"
   case chatClear = "channel.chat.clear"
 
+  case mock = "mock"
+
   var event: Event.Type {
     switch self {
     case .channelFollow: return ChannelFollowEvent.self
@@ -17,3 +19,5 @@ internal enum EventType: String, Decodable {
     }
   }
 }
+
+struct MockEvent: Event {}

--- a/Sources/Twitch/EventSub/KeepaliveTimer.swift
+++ b/Sources/Twitch/EventSub/KeepaliveTimer.swift
@@ -4,7 +4,10 @@ internal final actor KeepaliveTimer {
 
   private let onTimeout: @Sendable () async -> Void
 
-  init(duration: Duration = .seconds(10), onTimeout: @escaping @Sendable () async -> Void) {
+  init(
+    duration: Duration = .seconds(10),
+    onTimeout: @escaping @Sendable () async -> Void
+  ) {
     self.duration = duration
     self.onTimeout = onTimeout
 

--- a/Sources/Twitch/EventSub/KeepaliveTimer.swift
+++ b/Sources/Twitch/EventSub/KeepaliveTimer.swift
@@ -2,9 +2,9 @@ internal final actor KeepaliveTimer {
   private var task: Task<Void, Never>?
   private var duration: Duration
 
-  private let onTimeout: @Sendable () -> Void
+  private let onTimeout: @Sendable () async -> Void
 
-  init(duration: Duration = .seconds(10), onTimeout: @escaping @Sendable () -> Void) {
+  init(duration: Duration = .seconds(10), onTimeout: @escaping @Sendable () async -> Void) {
     self.duration = duration
     self.onTimeout = onTimeout
 
@@ -29,12 +29,12 @@ internal final actor KeepaliveTimer {
 
   private nonisolated static func makeTask(
     delay: Duration,
-    handler: @escaping @Sendable () -> Void
+    handler: @escaping @Sendable () async -> Void
   ) -> Task<Void, Never> {
     Task { [delay, handler] in
       do { try await Task.sleep(for: delay) } catch { return }
       if Task.isCancelled { return }
-      handler()
+      await handler()
     }
   }
 }

--- a/Sources/Twitch/Helix/TwitchClient+Helix.swift
+++ b/Sources/Twitch/Helix/TwitchClient+Helix.swift
@@ -109,7 +109,7 @@ extension TwitchClient {
 
     let (data, response): (Data, URLResponse)
     do {
-      (data, response) = try await self.urlSession.data(for: request)
+      (data, response) = try await self.network.data(for: request)
     } catch {
       throw HelixError.networkError(wrapped: error)
     }

--- a/Sources/Twitch/IRC/IRCConnectionPool.swift
+++ b/Sources/Twitch/IRC/IRCConnectionPool.swift
@@ -9,13 +9,13 @@ public actor IRCConnectionPool {
   private var connections: [IRCConnection] = []
 
   private let credentials: TwitchCredentials?
-  private let urlSession: URLSession
+  private let network: NetworkSession
 
   private var continuation: AsyncThrowingStream<IncomingMessage, Error>.Continuation?
 
-  init(with credentials: TwitchCredentials? = nil, urlSession: URLSession) {
+  init(with credentials: TwitchCredentials? = nil, network: NetworkSession) {
     self.credentials = credentials
-    self.urlSession = urlSession
+    self.network = network
   }
 
   internal func connect() async throws -> AsyncThrowingStream<IncomingMessage, Error> {
@@ -79,7 +79,7 @@ public actor IRCConnectionPool {
   }
 
   @discardableResult private func createConnection() async throws -> IRCConnection {
-    let connection = IRCConnection(credentials: credentials, urlSession: urlSession)
+    let connection = IRCConnection(credentials: credentials, network: network)
     let messageStream = try await connection.connect()
 
     Task {

--- a/Sources/Twitch/IRC/TwitchClient+IRC.swift
+++ b/Sources/Twitch/IRC/TwitchClient+IRC.swift
@@ -12,7 +12,7 @@ extension TwitchClient {
     return try await TwitchIRCClient(
       .authenticated(self.authentication),
       options: options,
-      urlSession: self.urlSession
+      network: self.network
     )
   }
 }

--- a/Sources/Twitch/IRC/TwitchIRCClient.swift
+++ b/Sources/Twitch/IRC/TwitchIRCClient.swift
@@ -26,7 +26,19 @@ public actor TwitchIRCClient {
   public init(
     _ authenticationStyle: AuthenticationStyle,
     options: Options = .init(),
-    urlSession: URLSession = URLSession(configuration: .default)
+    urlSession: URLSession
+  ) async throws {
+    try await self.init(
+      authenticationStyle,
+      options: options,
+      network: URLSessionNetworkSession(session: urlSession)
+    )
+  }
+
+  internal init(
+    _ authenticationStyle: AuthenticationStyle,
+    options: Options = .init(),
+    network: NetworkSession
   ) async throws {
     let credentials: TwitchCredentials? =
       switch authenticationStyle {
@@ -37,7 +49,7 @@ public actor TwitchIRCClient {
     if options.enableWriteConnection {
       self.writeConnection = IRCConnection(
         credentials: credentials,
-        urlSession: urlSession
+        network: network
       )
     } else {
       self.writeConnection = nil
@@ -45,7 +57,7 @@ public actor TwitchIRCClient {
 
     self.readConnectionPool = IRCConnectionPool(
       with: credentials,
-      urlSession: urlSession
+      network: network
     )
 
     try await writeConnection?.connect()

--- a/Sources/Twitch/Shared/Networking/NetworkSession.swift
+++ b/Sources/Twitch/Shared/Networking/NetworkSession.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+protocol NetworkSession: Sendable {
+  func data(for request: URLRequest) async throws -> (Data, URLResponse)
+  func webSocketTask(with url: URL) async -> WebSocketTask
+}
+
+struct URLSessionNetworkSession: NetworkSession, @unchecked Sendable {
+  let session: URLSession
+
+  func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+    try await session.data(for: request)
+  }
+
+  func webSocketTask(with url: URL) async -> WebSocketTask {
+    URLSessionWebSocketTaskAdapter(task: session.webSocketTask(with: url))
+  }
+}

--- a/Sources/Twitch/Shared/Networking/WebSocketTask.swift
+++ b/Sources/Twitch/Shared/Networking/WebSocketTask.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+protocol WebSocketTask: Sendable {
+  func resume() async
+  func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) async
+
+  func send(_ message: URLSessionWebSocketTask.Message, ) async throws
+
+  func receive(
+    completionHandler:
+      @Sendable @escaping (Result<URLSessionWebSocketTask.Message, Error>) -> Void
+  ) async
+
+  func receive() async throws -> URLSessionWebSocketTask.Message
+}
+
+final class URLSessionWebSocketTaskAdapter: WebSocketTask {
+  private let task: URLSessionWebSocketTask
+  init(task: URLSessionWebSocketTask) { self.task = task }
+
+  func resume() { task.resume() }
+
+  func cancel(
+    with closeCode: URLSessionWebSocketTask.CloseCode,
+    reason: Data?
+  ) { task.cancel(with: closeCode, reason: reason) }
+
+  func send(_ message: URLSessionWebSocketTask.Message) async throws {
+    try await task.send(message)
+  }
+
+  func receive(
+    completionHandler:
+      @Sendable @escaping (Result<URLSessionWebSocketTask.Message, Error>) -> Void
+  ) { task.receive(completionHandler: completionHandler) }
+
+  func receive() async throws -> URLSessionWebSocketTask.Message {
+    return try await task.receive()
+  }
+}

--- a/Sources/Twitch/TwitchClient.swift
+++ b/Sources/Twitch/TwitchClient.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public actor TwitchClient {
   internal let authentication: TwitchCredentials
-  internal let urlSession: URLSession
+  internal let network: NetworkSession
 
   internal let encoder = JSONEncoder()
   internal let decoder = JSONDecoder()
@@ -17,8 +17,19 @@ public actor TwitchClient {
     authentication: TwitchCredentials,
     urlSession: URLSession = URLSession(configuration: .default)
   ) {
+    let network = URLSessionNetworkSession(session: urlSession)
+
+    self.init(
+      authentication: authentication,
+      network: network)
+  }
+
+  internal init(
+    authentication: TwitchCredentials,
+    network: NetworkSession
+  ) {
     self.authentication = authentication
-    self.urlSession = urlSession
+    self.network = network
 
     self.encoder.dateEncodingStrategy = .iso8601withFractionalSeconds
     self.decoder.dateDecodingStrategy = .iso8601withFractionalSeconds
@@ -27,6 +38,8 @@ public actor TwitchClient {
     self.encoder.keyEncodingStrategy = .convertToSnakeCase
 
     self.eventSubClient = EventSubClient(
-      credentials: authentication, urlSession: urlSession, decoder: self.decoder)
+      credentials: authentication,
+      network: network,
+      decoder: self.decoder)
   }
 }

--- a/Tests/TwitchTests/EventSub/EventSubTests.swift
+++ b/Tests/TwitchTests/EventSub/EventSubTests.swift
@@ -12,19 +12,15 @@ extension EventSubSubscription where EventNotification == MockEvent {
 @Suite("General EventSub Tests")
 struct WebSocketClientTests {
   let twitch: TwitchClient
-  let mockingURLSession: MockNetworkSession
-  let mockingWebSocketTask: MockWebSocketTask
+  let session: MockNetworkSession = MockNetworkSession()
 
   init() async {
-    self.mockingWebSocketTask = MockWebSocketTask()
-    self.mockingURLSession = MockNetworkSession(webSocketTask: self.mockingWebSocketTask)
-
     self.twitch = TwitchClient(
       authentication: .init(oAuth: "", clientID: "", userID: "", userLogin: ""),
-      network: mockingURLSession)
+      network: session)
 
     let url = URL(string: "https://api.twitch.tv/helix/eventsub/subscriptions")!
-    await mockingURLSession.stub(
+    await session.stub(
       url: url, method: "POST",
       status: 200, headers: ["Content-Type": "application/json"],
       body: MockedMessages.mockEventSubSubscription)
@@ -33,24 +29,25 @@ struct WebSocketClientTests {
   @Test("Client creates WebSocket task and EventSub subscription")
   func testEventSubSetup() async throws {
     try await confirmation("Should create subscription", expectedCount: 1) { confirm in
-      await mockingURLSession.onRequest { _ in
+      await session.onRequest { _ in
         confirm()
       }
 
-      await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+      await session.simulateIncoming(.string(MockedMessages.welcomeMessage))
       _ = try await twitch.eventStream(for: .mock())
     }
 
-    #expect(await mockingWebSocketTask.didResume)
-    #expect(await mockingWebSocketTask.sentMessages.count == 0)
+    let task = try #require(await session.lastTask())
+    #expect(await task.didResume)
+    #expect(await task.sentMessages.count == 0)
   }
 
   @Test("Client receives EventSub Event messages")
   func testEventSubEvents() async throws {
-    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    await session.simulateIncoming(.string(MockedMessages.welcomeMessage))
     let stream = try await twitch.eventStream(for: .mock())
 
-    await mockingWebSocketTask.simulateIncoming(
+    await session.simulateIncoming(
       .string(MockedMessages.mockEventMessage))
 
     var iter = stream.makeAsyncIterator()
@@ -61,7 +58,7 @@ struct WebSocketClientTests {
 
   @Test("Client disconnects without keepalive")
   func testEventSubDisconnect() async throws {
-    await mockingWebSocketTask.simulateIncoming(
+    await session.simulateIncoming(
       .string(MockedMessages.welcomeMessage1SecondKeepalive))
 
     let stream = try await twitch.eventStream(for: .mock())
@@ -73,15 +70,17 @@ struct WebSocketClientTests {
     ) { _ = try await iter.next() }
 
     #expect({ if case .timedOut = error { true } else { false } }())
-    #expect(await mockingWebSocketTask.didCancel)
+
+    let task = try #require(await session.lastTask())
+    #expect(await task.didCancel)
   }
 
   @Test("Client disconnects on revocation message")
   func testEventSubDisconnectOnRevocation() async throws {
-    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    await session.simulateIncoming(.string(MockedMessages.welcomeMessage))
     let stream = try await twitch.eventStream(for: .mock())
 
-    await mockingWebSocketTask.simulateIncoming(
+    await session.simulateIncoming(
       .string(MockedMessages.mockRevocationMessage))
 
     var iter = stream.makeAsyncIterator()
@@ -91,32 +90,35 @@ struct WebSocketClientTests {
     ) { _ = try await iter.next() }
 
     #expect({ if case .revocation = error { true } else { false } }())
-    #expect(await !mockingWebSocketTask.didCancel)
+
+    let task = try #require(await session.lastTask())
+    #expect(await !task.didCancel)
   }
 
   @Test("Client reconnects on reconnection message")
   func testEventSubReconnect() async throws {
-    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    await session.simulateIncoming(.string(MockedMessages.welcomeMessage))
     let stream = try await twitch.eventStream(for: .mock())
 
-    await mockingWebSocketTask.simulateIncoming(
-      .string(MockedMessages.mockReconnectMessage))
+    await session.simulateIncoming(.string(MockedMessages.welcomeMessage), queue: true)
+    await session.simulateIncoming(.string(MockedMessages.mockEventMessage), queue: true)
 
-    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
-    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.mockEventMessage))
+    await session.simulateIncoming(
+      .string(MockedMessages.mockReconnectMessage))
 
     var iter = stream.makeAsyncIterator()
     _ = try await iter.next()
 
-    #expect(await mockingWebSocketTask.didCancel)
+    let task = try #require(await session.task(at: 0))
+    #expect(await task.didCancel)
   }
 
   @Test("Client throws error on disconnect")
   func testEventSubDiconnect() async throws {
-    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    await session.simulateIncoming(.string(MockedMessages.welcomeMessage))
     let stream = try await twitch.eventStream(for: .mock())
 
-    await mockingWebSocketTask.simulateError(WebSocketError.unsupportedDataReceived)
+    await session.simulateError(WebSocketError.unsupportedDataReceived)
 
     var iter = stream.makeAsyncIterator()
     let error = await #expect(
@@ -125,6 +127,8 @@ struct WebSocketClientTests {
     ) { _ = try await iter.next() }
 
     #expect({ if case .disconnected = error { true } else { false } }())
-    #expect(await mockingWebSocketTask.didCancel)
+
+    let task = try #require(await session.lastTask())
+    #expect(await task.didCancel)
   }
 }

--- a/Tests/TwitchTests/EventSub/EventSubTests.swift
+++ b/Tests/TwitchTests/EventSub/EventSubTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+
+@testable import Twitch
+
+extension EventSubSubscription where EventNotification == MockEvent {
+  public static func mock(version: String = "1") -> Self {
+    .init(type: EventType.mock.rawValue, version: version, condition: [:])
+  }
+}
+
+@Suite("General EventSub Tests")
+struct WebSocketClientTests {
+  let twitch: TwitchClient
+  let mockingURLSession: MockNetworkSession
+  let mockingWebSocketTask: MockWebSocketTask
+
+  init() async {
+    self.mockingWebSocketTask = MockWebSocketTask()
+    self.mockingURLSession = MockNetworkSession(webSocketTask: self.mockingWebSocketTask)
+
+    self.twitch = TwitchClient(
+      authentication: .init(oAuth: "", clientID: "", userID: "", userLogin: ""),
+      network: mockingURLSession)
+
+    let url = URL(string: "https://api.twitch.tv/helix/eventsub/subscriptions")!
+    await mockingURLSession.stub(
+      url: url, method: "POST",
+      status: 200, headers: ["Content-Type": "application/json"],
+      body: MockedMessages.mockEventSubSubscription)
+  }
+
+  @Test("Client creates WebSocket task and EventSub subscription")
+  func testEventSubSetup() async throws {
+    try await confirmation("Should create subscription", expectedCount: 1) { confirm in
+      await mockingURLSession.onRequest { _ in
+        confirm()
+      }
+
+      await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+      _ = try await twitch.eventStream(for: .mock())
+    }
+
+    #expect(await mockingWebSocketTask.didResume)
+    #expect(await mockingWebSocketTask.sentMessages.count == 0)
+  }
+
+  @Test("Client receives EventSub Event messages")
+  func testEventSubEvents() async throws {
+    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    let stream = try await twitch.eventStream(for: .mock())
+
+    await mockingWebSocketTask.simulateIncoming(
+      .string(MockedMessages.mockEventMessage))
+
+    var iter = stream.makeAsyncIterator()
+    let message = try await iter.next()
+
+    _ = try #require(message)
+  }
+
+  @Test("Client disconnects without keepalive")
+  func testEventSubDisconnect() async throws {
+    await mockingWebSocketTask.simulateIncoming(
+      .string(MockedMessages.welcomeMessage1SecondKeepalive))
+
+    let stream = try await twitch.eventStream(for: .mock())
+
+    var iter = stream.makeAsyncIterator()
+    let error = await #expect(
+      throws: EventSubError.self,
+      "Should disconnect without keepalive message"
+    ) { _ = try await iter.next() }
+
+    #expect({ if case .timedOut = error { true } else { false } }())
+    #expect(await mockingWebSocketTask.didCancel)
+  }
+
+  @Test("Client disconnects on revocation message")
+  func testEventSubDisconnectOnRevocation() async throws {
+    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    let stream = try await twitch.eventStream(for: .mock())
+
+    await mockingWebSocketTask.simulateIncoming(
+      .string(MockedMessages.mockRevocationMessage))
+
+    var iter = stream.makeAsyncIterator()
+    let error = await #expect(
+      throws: EventSubError.self,
+      "Should disconnect on revocation message"
+    ) { _ = try await iter.next() }
+
+    #expect({ if case .revocation = error { true } else { false } }())
+    #expect(await !mockingWebSocketTask.didCancel)
+  }
+
+  @Test("Client reconnects on reconnection message")
+  func testEventSubReconnect() async throws {
+    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    let stream = try await twitch.eventStream(for: .mock())
+
+    await mockingWebSocketTask.simulateIncoming(
+      .string(MockedMessages.mockReconnectMessage))
+
+    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.mockEventMessage))
+
+    var iter = stream.makeAsyncIterator()
+    _ = try await iter.next()
+
+    #expect(await mockingWebSocketTask.didCancel)
+  }
+
+  @Test("Client throws error on disconnect")
+  func testEventSubDiconnect() async throws {
+    await mockingWebSocketTask.simulateIncoming(.string(MockedMessages.welcomeMessage))
+    let stream = try await twitch.eventStream(for: .mock())
+
+    await mockingWebSocketTask.simulateError(WebSocketError.unsupportedDataReceived)
+
+    var iter = stream.makeAsyncIterator()
+    let error = await #expect(
+      throws: EventSubError.self,
+      "Should disconnect on revocation message"
+    ) { _ = try await iter.next() }
+
+    #expect({ if case .disconnected = error { true } else { false } }())
+    #expect(await mockingWebSocketTask.didCancel)
+  }
+}

--- a/Tests/TwitchTests/EventSub/MockResources/mockEventMessage.json
+++ b/Tests/TwitchTests/EventSub/MockResources/mockEventMessage.json
@@ -1,0 +1,25 @@
+{
+  "metadata": {
+    "message_id": "Lr70KAICVBHykvCd1o8wsM3KJ0R8ea8aJU1aNWYk4DU=",
+    "message_type": "notification",
+    "message_timestamp": "2025-08-30T01:10:13.390973799Z",
+    "subscription_type": "mock",
+    "subscription_version": "1"
+  },
+  "payload": {
+    "subscription": {
+      "id": "45ddd5d7-0d5d-4af3-9a07-624fca441fd1",
+      "status": "enabled",
+      "type": "mock",
+      "version": "2",
+      "condition": {},
+      "transport": {
+        "method": "websocket",
+        "session_id": "AgoQJr9vxmk9TD6-wyCCKkvi1BIGY2VsbC1j"
+      },
+      "created_at": "2025-08-30T01:09:19.745466841Z",
+      "cost": 0
+    },
+    "event": {}
+  }
+}

--- a/Tests/TwitchTests/EventSub/MockResources/mockEventSubSubscription.json
+++ b/Tests/TwitchTests/EventSub/MockResources/mockEventSubSubscription.json
@@ -1,0 +1,24 @@
+{
+  "data": [
+    {
+      "id": "45ddd5d7-0d5d-4af3-9a07-624fca441fd1",
+      "status": "enabled",
+      "type": "mock",
+      "version": "1",
+      "condition": {
+        "broadcaster_user_id": "618699913",
+        "user_id": "101676978"
+      },
+      "created_at": "2025-08-30T00:36:38.667761911Z",
+      "transport": {
+        "method": "websocket",
+        "session_id": "AgoQJr9vxmk9TD6-wyCCKkvi1BIGY2VsbC1j",
+        "connected_at": "2025-08-30T00:36:38Z"
+      },
+      "cost": 0
+    }
+  ],
+  "total": 2,
+  "max_total_cost": 10,
+  "total_cost": 0
+}

--- a/Tests/TwitchTests/EventSub/MockResources/reconnectMessage.json
+++ b/Tests/TwitchTests/EventSub/MockResources/reconnectMessage.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "message_id": "84c1e79a-2a4b-4c13-ba0b-4312293e9308",
+    "message_type": "session_reconnect",
+    "message_timestamp": "2022-11-18T09:10:11.634234626Z"
+  },
+  "payload": {
+    "session": {
+      "id": "AgoQ_54xDzTdSKqDTS4mIXTW0RIGY2VsbC1j",
+      "status": "reconnecting",
+      "keepalive_timeout_seconds": null,
+      "reconnect_url": "wss://eventsub.wss.twitch.tv",
+      "connected_at": "2022-11-16T10:11:12.634234626Z"
+    }
+  }
+}

--- a/Tests/TwitchTests/EventSub/MockResources/revocationMessage.json
+++ b/Tests/TwitchTests/EventSub/MockResources/revocationMessage.json
@@ -1,0 +1,24 @@
+{
+  "metadata": {
+    "message_id": "84c1e79a-2a4b-4c13-ba0b-4312293e9308",
+    "message_type": "revocation",
+    "message_timestamp": "2022-11-16T10:11:12.464757833Z",
+    "subscription_type": "channel.follow",
+    "subscription_version": "1"
+  },
+  "payload": {
+    "subscription": {
+      "id": "45ddd5d7-0d5d-4af3-9a07-624fca441fd1",
+      "status": "authorization_revoked",
+      "type": "mock",
+      "version": "1",
+      "cost": 0,
+      "condition": {},
+      "transport": {
+        "method": "websocket",
+        "session_id": "AgoQ_54xDzTdSKqDTS4mIXTW0RIGY2VsbC1j"
+      },
+      "created_at": "2022-11-16T10:11:12.464757833Z"
+    }
+  }
+}

--- a/Tests/TwitchTests/EventSub/MockResources/welcomeMessage.json
+++ b/Tests/TwitchTests/EventSub/MockResources/welcomeMessage.json
@@ -1,0 +1,17 @@
+{
+  "metadata": {
+    "message_id": "bf92492a-5520-469a-89a4-104fe2e8cc54",
+    "message_type": "session_welcome",
+    "message_timestamp": "2025-08-29T23:29:03.632793554Z"
+  },
+  "payload": {
+    "session": {
+      "id": "AgoQ_54xDzTdSKqDTS4mIXTW0RIGY2VsbC1j",
+      "status": "connected",
+      "connected_at": "2025-08-29T23:29:03.628242443Z",
+      "keepalive_timeout_seconds": 10,
+      "reconnect_url": null,
+      "recovery_url": null
+    }
+  }
+}

--- a/Tests/TwitchTests/EventSub/MockResources/welcomeMessage1SecondKeepalive.json
+++ b/Tests/TwitchTests/EventSub/MockResources/welcomeMessage1SecondKeepalive.json
@@ -1,0 +1,17 @@
+{
+  "metadata": {
+    "message_id": "bf92492a-5520-469a-89a4-104fe2e8cc54",
+    "message_type": "session_welcome",
+    "message_timestamp": "2025-08-29T23:29:03.632793554Z"
+  },
+  "payload": {
+    "session": {
+      "id": "AgoQ_54xDzTdSKqDTS4mIXTW0RIGY2VsbC1j",
+      "status": "connected",
+      "connected_at": "2025-08-29T23:29:03.628242443Z",
+      "keepalive_timeout_seconds": 1,
+      "reconnect_url": null,
+      "recovery_url": null
+    }
+  }
+}

--- a/Tests/TwitchTests/EventSub/MockedMessages.swift
+++ b/Tests/TwitchTests/EventSub/MockedMessages.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@testable import Twitch
+
+struct MockedMessages {
+  // Helix response for creating a subscription
+  static let mockEventSubSubscription = Bundle.module.url(
+    forResource: "mockEventSubSubscription", withExtension: "json")!.data
+
+  // MARK: - EventSub Messages
+
+  static let welcomeMessage = String(
+    data: Bundle.module.url(forResource: "welcomeMessage", withExtension: "json")!.data,
+    encoding: .utf8)!
+
+  static let welcomeMessage1SecondKeepalive = String(
+    data: Bundle.module.url(
+      forResource: "welcomeMessage1SecondKeepalive", withExtension: "json")!.data,
+    encoding: .utf8)!
+
+  static let mockRevocationMessage = String(
+    data: Bundle.module.url(forResource: "revocationMessage", withExtension: "json")!
+      .data,
+    encoding: .utf8)!
+
+  static let mockReconnectMessage = String(
+    data: Bundle.module.url(forResource: "reconnectMessage", withExtension: "json")!
+      .data,
+    encoding: .utf8)!
+
+  static let mockEventMessage = String(
+    data: Bundle.module.url(forResource: "mockEventMessage", withExtension: "json")!.data,
+    encoding: .utf8)!
+}

--- a/Tests/TwitchTests/Shared/MockNetworkSession.swift
+++ b/Tests/TwitchTests/Shared/MockNetworkSession.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+@testable import Twitch
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+actor MockNetworkSession: NetworkSession {
+  private let webSocketTask: WebSocketTask
+
+  struct Key: Hashable {
+    let url: URL
+    let method: String
+  }
+
+  private var stubs: [Key: (Data, HTTPURLResponse)] = [:]
+  private var onRequest: (@Sendable (URLRequest) -> Void)?
+
+  init(webSocketTask: WebSocketTask) {
+    self.webSocketTask = webSocketTask
+  }
+
+  func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+    onRequest?(request)
+
+    guard let url = request.url else { throw URLError(.badURL) }
+    let method = request.httpMethod ?? "GET"
+
+    if let hit = stubs[Key(url: url, method: method)] { return hit }
+    throw URLError(.unsupportedURL)
+  }
+
+  func webSocketTask(with url: URL) async -> WebSocketTask { webSocketTask }
+
+  func stub(
+    url: URL, method: String = "GET",
+    status: Int = 200,
+    headers: [String: String] = [:],
+    body: Data = Data()
+  ) {
+    let response = HTTPURLResponse(
+      url: url,
+      statusCode: status,
+      httpVersion: "HTTP/1.1",
+      headerFields: headers)!
+
+    stubs[Key(url: url, method: method)] = (body, response)
+  }
+
+  func onRequest(_ handler: @escaping @Sendable (URLRequest) -> Void) {
+    onRequest = handler
+  }
+
+  func reset() {
+    stubs.removeAll()
+    onRequest = nil
+  }
+}

--- a/Tests/TwitchTests/Shared/MockWebSocketTask.swift
+++ b/Tests/TwitchTests/Shared/MockWebSocketTask.swift
@@ -19,7 +19,10 @@ actor MockWebSocketTask: WebSocketTask {
   func cancel(
     with closeCode: URLSessionWebSocketTask.CloseCode,
     reason: Data?
-  ) { didCancel = true }
+  ) {
+    didCancel = true
+    pendingReceives.removeAll()
+  }
 
   func send(
     _ message: URLSessionWebSocketTask.Message

--- a/Tests/TwitchTests/Shared/MockWebSocketTask.swift
+++ b/Tests/TwitchTests/Shared/MockWebSocketTask.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+@testable import Twitch
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+actor MockWebSocketTask: WebSocketTask {
+  private(set) var didResume = false
+  private(set) var didCancel = false
+  private(set) var sentMessages: [URLSessionWebSocketTask.Message] = []
+  private var pendingReceives:
+    [@Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void] = []
+  private var pendingMessages: [URLSessionWebSocketTask.Message] = []
+
+  func resume() { didResume = true }
+
+  func cancel(
+    with closeCode: URLSessionWebSocketTask.CloseCode,
+    reason: Data?
+  ) { didCancel = true }
+
+  func send(
+    _ message: URLSessionWebSocketTask.Message
+  ) {
+    sentMessages.append(message)
+  }
+
+  func receive(
+    completionHandler:
+      @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void
+  ) {
+    guard pendingMessages.isEmpty else {
+      let message = pendingMessages.removeFirst()
+      completionHandler(.success(message))
+      return
+    }
+
+    pendingReceives.append(completionHandler)
+  }
+
+  func receive() async throws -> URLSessionWebSocketTask.Message {
+    return try await withCheckedThrowingContinuation { continuation in
+      receive {
+        continuation.resume(with: $0)
+      }
+    }
+  }
+
+  func simulateIncoming(_ message: URLSessionWebSocketTask.Message) {
+    guard !pendingReceives.isEmpty else {
+      pendingMessages.append(message)
+      return
+    }
+
+    let handler = pendingReceives.removeFirst()
+    handler(.success(message))
+  }
+
+  func simulateError(_ error: Error) {
+    guard !pendingReceives.isEmpty else { return }
+    let handler = pendingReceives.removeFirst()
+    handler(.failure(error))
+  }
+}


### PR DESCRIPTION
This needed an implementation for mocking WebSocket connections, done using dependency injection of a mocked URLSession into `TwitchClient`. A bunch of adjustments to concurrency had to made as well to account for additional `awaits` due to actor isolation.

Added a bunch of general tests for EventSub behavior on various different received message types.